### PR TITLE
Show current network diff/height rather than last block diff/height

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -293,6 +293,8 @@ function collectStats(){
                 }
                 var blockHeader = reply.block_header;
                 callback(null, {
+                    difficulty: blockHeader.difficulty,	
+                    height: blockHeader.height,
                     timestamp: blockHeader.timestamp,
                     reward: blockHeader.reward,
                     hash:  blockHeader.hash

--- a/lib/api.js
+++ b/lib/api.js
@@ -293,7 +293,7 @@ function collectStats(){
                 }
                 var blockHeader = reply.block_header;
                 callback(null, {
-                    difficulty: blockHeader.difficulty,	
+                    difficulty: blockHeader.difficulty,
                     height: blockHeader.height,
                     timestamp: blockHeader.timestamp,
                     reward: blockHeader.reward,

--- a/lib/api.js
+++ b/lib/api.js
@@ -283,7 +283,7 @@ function collectStats(){
                 callback(null, data);
             });
         },
-        network: function(callback){
+        lastblock: function(callback){
             apiInterfaces.rpcDaemon('getlastblockheader', {}, function(error, reply){
                 daemonFinished = Date.now();
                 if (error){
@@ -293,11 +293,23 @@ function collectStats(){
                 }
                 var blockHeader = reply.block_header;
                 callback(null, {
-                    difficulty: blockHeader.difficulty,
-                    height: blockHeader.height,
                     timestamp: blockHeader.timestamp,
                     reward: blockHeader.reward,
                     hash:  blockHeader.hash
+                });
+            });
+        },
+        network: function(callback){
+            apiInterfaces.rpcDaemon('get_info', {}, function(error, reply){
+                daemonFinished = Date.now();
+                if (error){
+                    log('error', logSystem, 'Error getting daemon data %j', [error]);
+                    callback(true);
+                    return;
+                }
+                callback(null, {
+                    difficulty: reply.difficulty,
+                    height: reply.height
                 });
             });
         },

--- a/website_example/pages/home.html
+++ b/website_example/pages/home.html
@@ -208,13 +208,13 @@ currentPage = {
         $('#networkLastBlockFound,#poolLastBlockFound').timeago('dispose');
     },
     update: function(){
-        $('#networkLastBlockFound').timeago('update', new Date(lastStats.network.timestamp * 1000).toISOString());
+        $('#networkLastBlockFound').timeago('update', new Date(lastStats.lastblock.timestamp * 1000).toISOString());
         
         updateText('networkHashrate', getReadableHashRateString(lastStats.network.difficulty / lastStats.config.coinDifficultyTarget) + '/sec');
         updateText('networkDifficulty', formatNumber(lastStats.network.difficulty.toString(), ' '));
         updateText('blockchainHeight', formatNumber(lastStats.network.height.toString(), ' '));
-        updateText('networkLastReward', getReadableCoins(lastStats.network.reward));
-        updateText('lastHash', lastStats.network.hash).setAttribute('href', getBlockchainUrl(lastStats.network.hash));
+        updateText('networkLastReward', getReadableCoins(lastStats.lastblock.reward));
+        updateText('lastHash', lastStats.lastblock.hash).setAttribute('href', getBlockchainUrl(lastStats.lastblock.hash));
 
         updateText('poolHashrate', getReadableHashRateString(lastStats.pool.hashrate) + '/sec');
         updateText('blocksTotal', lastStats.pool.totalBlocks.toString());

--- a/website_example/pages/market.html
+++ b/website_example/pages/market.html
@@ -324,7 +324,7 @@ function calcEstimateProfit(){
     try {
         var rateUnit = Math.pow(1000,parseInt($('#calcHashUnit').data('mul')));
         var hashRate = parseFloat($('#calcHashRate').val()) * rateUnit;
-        var profit = (hashRate * 86400 / lastStats.network.difficulty) * lastStats.network.reward;
+        var profit = (hashRate * 86400 / lastStats.network.difficulty) * lastStats.lastblock.reward;
         if (profit) {
             updateText('calcHashAmount1', getReadableCoins(profit));
             updateText('calcHashAmount2', getCurrencyPriceText(profit));

--- a/website_example/pages/pool_blocks.html
+++ b/website_example/pages/pool_blocks.html
@@ -118,7 +118,7 @@ function parseBlock(height, serializedBlock){
         reward: parts[5]
     };
 
-    var toGo = lastStats.config.depth - (lastStats.network.height - block.height);
+    var toGo = lastStats.config.depth - (lastStats.network.height - 1 - block.height);
     if(toGo > 1){
         block.maturity = toGo + ' to go';
     } 

--- a/website_example/pages/pool_blocks.html
+++ b/website_example/pages/pool_blocks.html
@@ -118,7 +118,7 @@ function parseBlock(height, serializedBlock){
         reward: parts[5]
     };
 
-    var toGo = lastStats.config.depth - (lastStats.network.height - 1 - block.height);
+    var toGo = lastStats.config.depth - (lastStats.network.height - block.height - 1);
     if(toGo > 1){
         block.maturity = toGo + ' to go';
     } 

--- a/website_example/pages/worker_stats.html
+++ b/website_example/pages/worker_stats.html
@@ -156,7 +156,7 @@ function fetchAddressStats(longpoll){
 
             var userRoundHashes = parseInt(data.stats.roundHashes || 0);
 	    var poolRoundHashes = parseInt(lastStats.pool.roundHashes || 0);
-	    var lastReward = parseFloat(lastStats.network.reward || 0);
+	    var lastReward = parseFloat(lastStats.lastblock.reward || 0);
 	    
             var poolFee = lastStats.config.fee;
             if (Object.keys(lastStats.config.donation).length) {

--- a/website_example/pages/worker_stats.html
+++ b/website_example/pages/worker_stats.html
@@ -155,8 +155,8 @@ function fetchAddressStats(longpoll){
             updateText('yourPendingBalance', getReadableCoins(data.stats.balance));
 
             var userRoundHashes = parseInt(data.stats.roundHashes || 0);
-	    var poolRoundHashes = parseInt(lastStats.pool.roundHashes || 0);
-	    var lastReward = parseFloat(lastStats.lastblock.reward || 0);
+            var poolRoundHashes = parseInt(lastStats.pool.roundHashes || 0);
+            var lastReward = parseFloat(lastStats.lastblock.reward || 0);
 	    
             var poolFee = lastStats.config.fee;
             if (Object.keys(lastStats.config.donation).length) {


### PR DESCRIPTION
The difficulty and height on the main page currently show the
difficulty and height of the previous block, but the pool is actually
currently working on a different diff/height.

This commit fetches the current network diff/height from the daemon and
updates the display to show them rather than the previous block values.