### PR TITLE
Defer payment notification until payments complete

### DIFF
--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -194,6 +194,7 @@ function runInterval(){
             }
 
             var timeOffset = 0;
+            var notify_miners = [];
 
             async.filter(transferCommands, function(transferCmd, cback){
                 apiInterfaces.rpcWallet('transfer', transferCmd.rpc, function(error, result){
@@ -216,7 +217,7 @@ function runInterval(){
                         Object.keys(transferCmd.rpc.destinations).length
                     ].join(':')]);
 
-
+                    var notify_miners_on_success = [];
                     for (var i = 0; i < transferCmd.rpc.destinations.length; i++){
                         var destination = transferCmd.rpc.destinations[i];
                         if (transferCmd.rpc.payment_id){
@@ -229,10 +230,10 @@ function runInterval(){
                             transferCmd.rpc.mixin
                         ].join(':')]);
 
-                        notifications.sendToMiner(destination.address, 'payment', {
+                        notify_miners_on_success.push({
                             'AMOUNT': utils.getReadableCoins(destination.amount, 4, false),
                             'ADDRESS': destination.address
-		        });
+                        });
                     }
 
                     log('info', logSystem, 'Payments sent via wallet daemon %j', [result]);
@@ -243,12 +244,23 @@ function runInterval(){
                             cback(false);
                             return;
                         }
+
+                        for (var m in notify_miners_on_success) {
+                            notify_miners.push(notify_miners_on_success[m]);
+                        }
+
                         cback(true);
                     });
                 });
             }, function(succeeded){
                 var failedAmount = transferCommands.length - succeeded.length;
                 log('info', logSystem, 'Payments splintered and %d successfully sent, %d failed', [succeeded.length, failedAmount]);
+
+                for (var m in notify_miners) {
+                    var notify = notify_miners[m];
+                    notifications.sendToMiner(notify['ADDRESS'], notify);
+                }
+
                 callback(null);
             });
 


### PR DESCRIPTION
If a payment notification fails we can end up in a situation where a
payment has gone ahead but isn't yet recorded in the pool, leading to a
double payment.

This commit defers invoking the notification code until after payments
are complete to avoid the potential issue.