### PR TITLE
Update pool.js

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -502,7 +502,13 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                 sendReply('Invalid job id');
                 return;
             }
-
+			
+			if(!params.nonce || !params.result){
+				sendReply('Attack detected');
+				console.warn(threadName + 'Malformed miner share: ' + JSON.stringify(params) + ' from ' + miner.logString);
+				return;
+			}
+			
             if (!noncePattern.test(params.nonce)) {
                 var minerText = miner ? (' ' + miner.login + '@' + miner.ip) : '';
                 log('warn', logSystem, 'Malformed nonce: ' + JSON.stringify(params) + ' from ' + minerText);
@@ -891,8 +897,12 @@ function startPoolServerTcp(callback){
 
                             break;
                         }
-                        handleMessage(socket, jsonData, pushMessage);
-                    }
+						    try {
+							    handleMessage(socket, jsonData, pushMessage);
+						    }catch (e){
+							    console.warn(threadName + "Malformed message from " + socket.remoteAddress + " generated an exception. Message: " + message);
+						    }
+                     }
                     dataBuffer = incomplete;
                 }
             }).on('error', function(err){


### PR DESCRIPTION
Security fix for an attack allowing to crash the nodejs process by not sending the hash result.  
Not sending the result variable lead to generating an exception.  
  
This attack can lead to and simplify a 51% attack on a coin if not patched with a coordinated attack: crashing pools and huge hashrate/corrupted daemon on the other part.  
  
This patch check that this variable exist before processing the share.  
It also prevent possible future malformed packet to crash the pool by catching every exception on the handleMessage function