### PR TITLE
Add hard fork version and cn_variant to the log

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -762,11 +762,13 @@ function processShare(miner, job, blockTemplate, nonce, resultHash){
     }
     else {
         convertedBlob = utils.cnUtil.convert_blob(shareBuffer, cnBlobType);
+        var hard_fork_version = convertedBlob[0];
         if (cnAlgorithm == "cryptonight_heavy") {
             hash = cryptoNight(convertedBlob);
         } else {
             hash = cryptoNight(convertedBlob, cnVariant);
         }
+        log('info', logSystem, 'NodeJS Pool Mining cn_variant %s, Hard Fork Version: %s', [cnVariant, hard_fork_version]);
         shareType = 'valid';
     }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -768,7 +768,7 @@ function processShare(miner, job, blockTemplate, nonce, resultHash){
         } else {
             hash = cryptoNight(convertedBlob, cnVariant);
         }
-        log('info', logSystem, 'NodeJS Pool Mining cn_variant %s, Hard Fork Version: %s', [cnVariant, hard_fork_version]);
+        log('info', logSystem, 'Mining pool algorithm: %s variant %d, Hard fork version: %d', [cnAlgorithm, cnVariant, hard_fork_version]);
         shareType = 'valid';
     }
 


### PR DESCRIPTION
Pool ops can easily see what hard fork version and cn_variant they are mining on for a particular coin in the log.
This is tested on a few of my pools and I thought you might like the contribution. More to come if this get's merged. Thank you for your contributions. 
Screenshot: 
![alt text](https://image.ibb.co/eFfqvy/logs.png "Hard Fork Version, cn_variant")
