### PR TITLE
Use css rules for chart colors

### DIFF
--- a/website_example/pages/home.html
+++ b/website_example/pages/home.html
@@ -179,6 +179,7 @@
             <h4><span tkey="hashRate">Hash Rate</span></h4>
             <div class="chart">
                 <canvas id="chart_hashrate"></canvas>
+                <a class="chart-style"></a>
             </div> 
         </div>        
     </div>
@@ -187,6 +188,7 @@
             <h4><span tkey="difficulty">Difficulty</span></h4>
             <div class="chart">
                 <canvas id="chart_diff"></canvas>
+                <a class="chart-style"></a>
             </div> 
         </div>
     </div>
@@ -195,6 +197,7 @@
             <h4><span tkey="miners">Miners</span></h4>
             <div class="chart">
                 <canvas id="chart_miners"></canvas>
+                <a class="chart-style"></a>
             </div> 
         </div> 
     </div>    
@@ -203,6 +206,7 @@
             <h4><span tkey="workers">Workers</span></h4>
             <div class="chart">
                 <canvas id="chart_workers"></canvas>
+                <a class="chart-style"></a>
             </div> 
         </div> 
     </div>    
@@ -295,7 +299,18 @@ function createCharts() {
 
     for (var graphType in graphData) {
         if (graphData[graphType].values.length > 1) {
-            $chart = $('#chart_'+graphType);
+            var $chart = $('#chart_'+graphType);
+            var bgcolor = null, bordercolor = null, borderwidth = null;
+            var colorelem = $chart.siblings('a.chart-style');
+            if (colorelem.length == 1) {
+                bgcolor = colorelem.css('background-color');
+                bordercolor = colorelem.css('border-left-color');
+                borderwidth = parseFloat(colorelem.css('width'));
+            }
+            if (bgcolor === null) bgcolor = 'rgba(3, 169, 244, .4)';
+            if (bordercolor === null) bordercolor = '#03a9f4';
+            if (borderwidth === null || isNaN(borderwidth)) borderwidth = 1;
+
             var chartObj = new Chart(document.getElementById('chart_'+graphType), {
                 type: 'line',
                 data: {
@@ -304,9 +319,9 @@ function createCharts() {
                         data: graphData[graphType].values,
                         dataType: graphType,
                         fill: true,
-                        backgroundColor: 'rgba(3, 169, 244, .4)',
-                        borderColor: '#03a9f4',
-                        borderWidth: 1
+                        backgroundColor: bgcolor,
+                        borderColor: bordercolor,
+                        borderWidth: borderwidth
                     }]
                 },
                 options: {

--- a/website_example/pages/market.html
+++ b/website_example/pages/market.html
@@ -7,6 +7,7 @@
             <h4><span tkey="priceIn">Price in</span> <span id="priceChartCurrency">USD</span></h4>
             <div class="chart">
                 <canvas id="chart_price"></canvas>
+                <a class="chart-style"></a>
             </div>
         </div>        
     </div>
@@ -15,6 +16,7 @@
             <h4><span tkey="hashPer">Hash/</span><span id="profitChartCurrency">USD</span> <span data-toggle="tooltip" data-placement="top" data-original-title="Reward * Rate / Difficulty"><i class="fa fa-question-circle"></i></span></h4>
             <div class="chart">
                 <canvas id="chart_profit"></canvas>
+                <a class="chart-style"></a>
             </div>
         </div>
     </div>
@@ -207,7 +209,17 @@ function createCharts() {
 
     for(var graphType in graphData) {
         if (graphData[graphType].values.length > 1) {
-            $chart = $('#chart_'+graphType);
+            var $chart = $('#chart_'+graphType);
+            var bgcolor = null, bordercolor = null, borderwidth = null;
+            var colorelem = $chart.siblings('a.chart-style');
+            if (colorelem.length == 1) {
+                bgcolor = colorelem.css('background-color');
+                bordercolor = colorelem.css('border-left-color');
+                borderwidth = parseFloat(colorelem.css('width'));
+            }
+            if (bgcolor === null) bgcolor = 'rgba(3, 169, 244, .4)';
+            if (bordercolor === null) bordercolor = '#03a9f4';
+            if (borderwidth === null || isNaN(borderwidth)) borderwidth = 1;
             var chartObj = new Chart(document.getElementById('chart_'+graphType), {
                 type: 'line',
                 data: {
@@ -216,9 +228,9 @@ function createCharts() {
                         data: graphData[graphType].values,
                         dataType: graphType,
                         fill: true,
-                        backgroundColor: 'rgba(3, 169, 244, .4)',
-                        borderColor: '#03a9f4',
-                        borderWidth: 1
+                        backgroundColor: bgcolor,
+                        borderColor: bordercolor,
+                        borderWidth: borderwidth
                     }]
                 },
                 options: {

--- a/website_example/pages/pool_blocks.html
+++ b/website_example/pages/pool_blocks.html
@@ -47,6 +47,7 @@
     <h4 id="blocksChartTitle">Blocks found</h4>
     <div class="chart" style="height:200px;">
         <canvas id="blocksChartObj"></canvas>
+        <a class="chart-style"></a>
     </div>
 </div>
 
@@ -132,6 +133,18 @@ function generateChart(data) {
         values.push(data[key]);
     }
 
+    var $chart = $('#blocksChartObj');
+    var bgcolor = null, bordercolor = null, borderwidth = null;
+    var colorelem = $chart.siblings('a.chart-style');
+    if (colorelem.length == 1) {
+        bgcolor = colorelem.css('background-color');
+        bordercolor = colorelem.css('border-left-color');
+        borderwidth = parseFloat(colorelem.css('width'));
+    }
+    if (bgcolor === null) bgcolor = 'rgba(3, 169, 244, .4)';
+    if (bordercolor === null) bordercolor = '#03a9f4';
+    if (borderwidth === null || isNaN(borderwidth)) borderwidth = 1;
+
     var chart = new Chart(document.getElementById('blocksChartObj'), {
         type: 'bar',
         data: {
@@ -140,9 +153,9 @@ function generateChart(data) {
                 label: 'Blocks',
                 data: values,
                 fill: false,
-                backgroundColor: 'rgba(3, 169, 244, .4)',
-                borderColor: '#03a9f4',
-                borderWidth: 1
+                backgroundColor: bgcolor,
+                borderColor: bordercolor,
+                borderWidth: borderwidth
             }]
         },
         options: {
@@ -164,7 +177,7 @@ function generateChart(data) {
             }
         }
     });
-    $('#blocksChart').show();
+    $chart.show();
     displayedChart = true;
 }
 

--- a/website_example/pages/worker_stats.html
+++ b/website_example/pages/worker_stats.html
@@ -22,7 +22,8 @@
             </div>
             <div class="col-sm-6 userChart">
                 <div class="chart">
-                    <canvas id="chart_hashrate"></canvas">
+                    <canvas id="chart_hashrate"></canvas>
+                    <a class="chart-style"></a>
                 </div>
             </div> 
 	</div>
@@ -39,7 +40,8 @@
             </div>
             <div class="col-sm-6 userChart">
                 <div class="chart">
-                    <canvas id="chart_payments"></canvas">
+                    <canvas id="chart_payments"></canvas>
+                    <a class="chart-style"></a>
                 </div>
             </div>
         </div>       
@@ -274,7 +276,18 @@ function createCharts() {
 
     for (var graphType in graphData) {
         if (graphData[graphType].values.length > 1) {
-            $chart = $('#chart_'+graphType);
+            var $chart = $('#chart_'+graphType);
+            var bgcolor = null, bordercolor = null, borderwidth = null;
+            var colorelem = $chart.siblings('a.chart-style');
+            if (colorelem.length == 1) {
+                bgcolor = colorelem.css('background-color');
+                bordercolor = colorelem.css('border-left-color');
+                borderwidth = parseFloat(colorelem.css('width'));
+            }
+            if (bgcolor === null) bgcolor = 'rgba(3, 169, 244, .4)';
+            if (bordercolor === null) bordercolor = '#03a9f4';
+            if (borderwidth === null || isNaN(borderwidth)) borderwidth = 1;
+
             var chartObj = new Chart(document.getElementById('chart_'+graphType), {
                 type: 'line',
                 data: {
@@ -283,9 +296,9 @@ function createCharts() {
                         data: graphData[graphType].values,
                         dataType: graphType,
                         fill: true,
-                        backgroundColor: 'rgba(3, 169, 244, .4)',
-                        borderColor: '#03a9f4',
-                        borderWidth: 1
+                        backgroundColor: bgcolor,
+                        borderColor: bordercolor,
+                        borderWidth: borderwidth
                     }]
                 },
                 options: {

--- a/website_example/themes/default.css
+++ b/website_example/themes/default.css
@@ -587,6 +587,12 @@ table th.sort:hover{
   text-align: center;
   font-size: 21px;
 }
+.chart a.chart-style {
+  display: none; /* never displayed; we just use it to store the following colors: */
+  background-color: rgba(3, 169, 244, .4);
+  border-color: #03a9f4;
+  width: 1px; /* controls the chart border width (must be specified in px) */
+}
 
 /* Market Rates */
 #marketStats  {


### PR DESCRIPTION
While recently restyling my pool, I found that changing the colour of the charts requires editing the javascript, which doesn't seem particularly nice (and makes upgrades more difficult).  I came up with a solution to control the colours via the css, so that you can override it with an addition to `custom.css`.

This adds a hidden `<a>` tag after each chart `<canvas>` with a css-defined background-color, border-color, and width.  These are then used by the chart javascript to set the chart's background-color, border-color, and border-width.

The main advantage here is that it allows a site to change the chart colors via custom.css rather than needing to edit the javascript that generates the charts.

It's also possible to color just one chart differently by adding css such as:
```CSS
.chart canvas#chart_diff+a.chart-style {
  background-color: rgba(255, 0, 0, .4);
  border-color: #ff0000;
  width: 2px;
}
```