### PR TITLE
floatToString removing trailing significant digits

### DIFF
--- a/website_example/js/common.js
+++ b/website_example/js/common.js
@@ -128,7 +128,7 @@ function updateText(elementId, text){
 
 // Convert float to string
 function floatToString(float) {
-    return float.toFixed(6).replace(/[0\.]+$/, '');
+    return float.toFixed(6).replace(/\.0+$|0+$/, '');
 }
 
 // Format number


### PR DESCRIPTION
If floatToString is given a number such as 10.0 it ends up truncating
it to "1" instead of "10".  This fixes it to only remove 0s after the
decimal point (including the decimal point if only 0s follow it).