### PR TITLE
Clear chart intervals when destroying a page

### DIFF
--- a/website_example/pages/home.html
+++ b/website_example/pages/home.html
@@ -212,11 +212,16 @@
 <script>
 // Charts initialized
 var chartsInitialized = false;
+var intervalChartsUpdate;
 
 // Update current page
 currentPage = {
     destroy: function(){
         $('#networkLastBlockFound,#poolLastBlockFound').timeago('dispose');
+        if (chartsInitialized) {
+            chartsInitialized = false;
+            clearInterval(intervalChartsUpdate);
+        }
     },
     update: function(){
         $('#networkLastBlockFound').timeago('update', new Date(lastStats.lastblock.timestamp * 1000).toISOString());
@@ -267,7 +272,7 @@ currentPage = {
         updateText('currentEffort', (lastStats.pool.roundHashes / lastStats.network.difficulty * 100).toFixed(1) + '%');
 
         if (lastStats.charts && !chartsInitialized) {
-            var intervalChartsUpdate = setInterval(createCharts, 60*1000);
+            intervalChartsUpdate = setInterval(createCharts, 60*1000);
             createCharts();
             chartsInitialized = true;
         }

--- a/website_example/pages/market.html
+++ b/website_example/pages/market.html
@@ -56,10 +56,16 @@ if (typeof cryptonatorWidget !== 'undefined' && typeof marketCurrencies === 'und
 
 // Charts initialized
 var chartsInitialized = false;
+var intervalChartsUpdate;
 
 // Update current page
 currentPage = {
-    destroy: function(){},
+    destroy: function(){
+        if (chartsInitialized) {
+            chartsInitialized = false;
+            clearInterval(intervalChartsUpdate);
+        }
+    },
     update: function(){
         priceSource = lastStats.config.priceSource || 'cryptonator';
         priceCurrency = lastStats.config.priceCurrency || 'USD';
@@ -71,7 +77,7 @@ currentPage = {
         calcEstimateProfit();
 	
         if (lastStats.charts && !chartsInitialized) {
-            var intervalChartsUpdate = setInterval(createCharts, 60*1000);
+            intervalChartsUpdate = setInterval(createCharts, 60*1000);
             createCharts();
             chartsInitialized = true;
         }	

--- a/website_example/pages/worker_stats.html
+++ b/website_example/pages/worker_stats.html
@@ -97,6 +97,7 @@
 // Charts
 var userChartsData = null;
 var chartsInitialized = false;
+var intervalChartsUpdate;
 
 // Update current page
 currentPage = {
@@ -105,6 +106,10 @@ currentPage = {
         if (xhrAddressPoll) xhrAddressPoll.abort();
         if (addressTimeout) clearTimeout(addressTimeout);
         if (xhrGetPayments) xhrGetPayments.abort();
+        if (chartsInitialized) {
+            chartsInitialized = false;
+            clearInterval(intervalChartsUpdate);
+        }
     },
     update: function(){}
 };
@@ -186,7 +191,7 @@ function fetchAddressStats(longpoll){
             if (data.charts) {
                 userChartsData = data.charts;
                 if (!chartsInitialized) {
-                    var intervalChartsUpdate = setInterval(createCharts, 60*1000);
+                    intervalChartsUpdate = setInterval(createCharts, 60*1000);
                     createCharts();
                     chartsInitialized = true;
                 }


### PR DESCRIPTION
The intervals for drawing charts don't get destroyed, which can cause
some chart wonkiness such as the worker stats page getting replaced
with the overall pool hashrate (since the canvas id's are the same).
It can also cause some chart flickering when switching back and forth
between pages, since the repeated page ends up with multiple intervals
trying to draw the same chart.

This commit removes the interval when the page is destroyed so that
there should only be one chart drawing interval active at a time.