### PR TITLE
Fix `/notify ADDR` and `/report ADDR` telegram commands

### DIFF
--- a/lib/telegramBot.js
+++ b/lib/telegramBot.js
@@ -230,7 +230,7 @@ bot.onText(new RegExp('^'+botCommands['notify']+'$', 'i'), (telegramMsg) => {
     });
 });
 
-bot.onText(new RegExp('^'+botCommands['notify']+' (.*)$', 'i'), (msg, match) => {
+bot.onText(new RegExp('^'+botCommands['notify']+' (.*)$', 'i'), (telegramMsg, match) => {
     if (telegramMsg.from.id != telegramMsg.chat.id) return ;
 
     var address = (match && match[1]) ? match[1].trim() : '';

--- a/lib/telegramBot.js
+++ b/lib/telegramBot.js
@@ -162,7 +162,7 @@ bot.onText(new RegExp('^'+botCommands['report']+'$', 'i'), (telegramMsg) => {
     });
 });
 
-bot.onText(new RegExp('^'+botCommands['report']+' (.*)$', 'i'), (telegramMsg) => {
+bot.onText(new RegExp('^'+botCommands['report']+' (.*)$', 'i'), (telegramMsg, match) => {
     if (telegramMsg.from.id != telegramMsg.chat.id) return ;
 
     var address = (match && match[1]) ? match[1].trim() : '';


### PR DESCRIPTION
Typo in the input variable broke the notify ADDR command.

Fixes #203 
Fixes #176 