### PR TITLE
Slush reward updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -327,9 +327,7 @@ Explanation for each field:
     More about it here: https://mining.bitcoin.cz/help/#!/manual/rewards */
     "slushMining": {
         "enabled": false, // Enables slush mining. Recommended for pools catering to professional miners
-        "weight": 300, // Defines how fast the score assigned to a share declines in time. The value should roughly be equivalent to the average round duration in seconds divided by 8. When deviating by too much numbers may get too high for JS.
-        "blockTime": 60
-        "lastBlockCheckRate": 1 // How often the pool checks the timestamp of the last block. Lower numbers increase load but raise precision of the share value
+        "weight": 300 // Defines how fast the score assigned to a share declines in time. The value should roughly be equivalent to the average round duration in seconds divided by 8. When deviating by too much numbers may get too high for JS.
     }
 },
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -187,12 +187,13 @@ function collectStats(){
         ['hgetall', config.coin + ':stats'],
         ['zrange', config.coin + ':blocks:candidates', 0, -1, 'WITHSCORES'],
         ['zrevrange', config.coin + ':blocks:matured', 0, config.api.blocks - 1, 'WITHSCORES'],
-        ['hgetall', config.coin + ':shares:roundCurrent'],
+        ['hgetall', config.coin + ':scores:roundCurrent'],
         ['hgetall', config.coin + ':stats'],
         ['zcard', config.coin + ':blocks:matured'],
         ['zrevrange', config.coin + ':payments:all', 0, config.api.payments - 1, 'WITHSCORES'],
         ['zcard', config.coin + ':payments:all'],
-        ['keys', config.coin + ':payments:*']
+        ['keys', config.coin + ':payments:*'],
+        ['hgetall', config.coin + ':shares_actual:roundCurrent'],
     ];
 
     var windowTime = (((Date.now() / 1000) - config.api.hashrateWindow) | 0).toString();
@@ -222,6 +223,7 @@ function collectStats(){
                     miners: 0,
                     workers: 0,
                     hashrate: 0,
+                    roundScore: 0,
                     roundHashes: 0
                 };
 
@@ -262,18 +264,24 @@ function collectStats(){
 
                 data.hashrate = Math.round(totalShares / config.api.hashrateWindow);
 
-                data.roundHashes = 0;
-        
+                data.roundScore = 0;
+
                 if (replies[5]){
                     for (var miner in replies[5]){
-                        var roundHashes = 0;
-                        if (config.poolServer.slushMining.enabled) {
-                            roundHashes = parseInt(replies[5][miner]) / Math.pow(Math.E, ((data.lastBlockFound - dateNowSeconds) / config.poolServer.slushMining.weight)); //TODO: Abstract: If something different than lastBlockfound is used for scoreTime, this needs change.
-                        }
-                        else {
-                            roundHashes = parseInt(replies[5][miner]);
-                        }
+                        var roundScore = parseFloat(replies[5][miner]);
             
+                        data.roundScore += roundScore;
+
+                        if (!minerStats[miner]) { minerStats[miner] = {}; }
+                        minerStats[miner]['roundScore'] = roundScore;
+                    }
+                }
+
+                data.roundHashes = 0;
+
+                if (replies[11]){
+                    for (var miner in replies[11]){
+                        var roundHashes = parseInt(replies[11][miner])
                         data.roundHashes += roundHashes;
 
                         if (!minerStats[miner]) { minerStats[miner] = {}; }
@@ -323,7 +331,6 @@ function collectStats(){
                 maxPaymentThreshold: config.payments.maxPayment || null,
                 transferFee: config.payments.transferFee,
                 denominationUnit: config.payments.denomination,
-                blockTime: config.poolServer.slushMining.blockTime,
                 slushMiningEnabled: config.poolServer.slushMining.enabled,
                 weight: config.poolServer.slushMining.weight,
                 priceSource: config.prices ? config.prices.source : 'cryptonator',
@@ -535,6 +542,7 @@ function broadcastWorkerStats(address, destinations) {
 
         var stats = replies[0];
         stats.hashrate = minerStats[address] && minerStats[address]['hashrate'] ? minerStats[address]['hashrate'] : 0;
+        stats.roundScore = minerStats[address] && minerStats[address]['roundScore'] ? minerStats[address]['roundScore'] : 0;
         stats.roundHashes = minerStats[address] && minerStats[address]['roundHashes'] ? minerStats[address]['roundHashes'] : 0;
 
         var paymentsData = replies[1];
@@ -669,6 +677,7 @@ function handleMinerStats(urlParts, response){
         
             var stats = replies[0];
             stats.hashrate = minerStats[address] && minerStats[address]['hashrate'] ? minerStats[address]['hashrate'] : 0;
+            stats.roundScore = minerStats[address] && minerStats[address]['roundScore'] ? minerStats[address]['roundScore'] : 0;
             stats.roundHashes = minerStats[address] && minerStats[address]['roundHashes'] ? minerStats[address]['roundHashes'] : 0;
 
             var paymentsData = replies[1];
@@ -1422,6 +1431,7 @@ function handleAdminUsers(response){
                         lastShare: data[2],
                         hashes: data[3],
                         hashrate: minerStats[address] && minerStats[address]['hashrate'] ? minerStats[address]['hashrate'] : 0,
+                        roundScore: minerStats[address] && minerStats[address]['roundScore'] ? minerStats[address]['roundScore'] : 0,
                         roundHashes: minerStats[address] && minerStats[address]['roundHashes'] ? minerStats[address]['roundHashes'] : 0
                     };
                 }

--- a/lib/blockUnlocker.js
+++ b/lib/blockUnlocker.js
@@ -12,6 +12,8 @@ var apiInterfaces = require('./apiInterfaces.js')(config.daemon, config.wallet, 
 var notifications = require('./notifications.js');
 var utils = require('./utils.js');
 
+var slushMiningEnabled = config.poolServer.slushMining && config.poolServer.slushMining.enabled;
+
 // Initialize log system
 var logSystem = 'unlocker';
 require('./exceptionWriter.js')(logSystem);
@@ -49,7 +51,8 @@ function runInterval(){
                         hash: parts[0],
                         time: parts[1],
                         difficulty: parts[2],
-                        shares: parts[3]
+                        shares: parts[3],
+                        score: parts.length >= 5 ? parts[4] : parts[3]
                     });
                 }
 
@@ -101,7 +104,7 @@ function runInterval(){
         function(blocks, callback){
 
             var redisCommands = blocks.map(function(block){
-                return ['hgetall', config.coin + ':shares:round' + block.height];
+                return ['hgetall', config.coin + ':scores:round' + block.height];
             });
 
 
@@ -112,8 +115,8 @@ function runInterval(){
                     return;
                 }
                 for (var i = 0; i < replies.length; i++){
-                    var workerShares = replies[i];
-                    blocks[i].workerShares = workerShares;
+                    var workerScores = replies[i];
+                    blocks[i].workerScores = workerScores;
                 }
                 callback(null, blocks);
             });
@@ -126,7 +129,7 @@ function runInterval(){
             blocks.forEach(function(block){
                 if (!block.orphaned) return;
 
-                orphanCommands.push(['del', config.coin + ':shares:round' + block.height]);
+                orphanCommands.push(['del', config.coin + ':scores:round' + block.height]);
 
                 orphanCommands.push(['zrem', config.coin + ':blocks:candidates', block.serialized]);
                 orphanCommands.push(['zadd', config.coin + ':blocks:matured', block.height, [
@@ -137,10 +140,10 @@ function runInterval(){
                     block.orphaned
                 ].join(':')]);
 
-                if (block.workerShares) {
-                    var workerShares = block.workerShares;
-                    Object.keys(workerShares).forEach(function (worker) {
-                        orphanCommands.push(['hincrby', config.coin + ':shares:roundCurrent', worker, workerShares[worker]]);
+                if (block.workerScores && !slushMiningEnabled) {
+                    var workerScores = block.workerScores;
+                    Object.keys(workerScores).forEach(function (worker) {
+                        orphanCommands.push(['hincrby', config.coin + ':scores:roundCurrent', worker, workerScores[worker]]);
                     });
                 }
 
@@ -178,7 +181,7 @@ function runInterval(){
                 if (block.orphaned) return;
                 totalBlocksUnlocked++;
 
-                unlockedBlocksCommands.push(['del', config.coin + ':shares:round' + block.height]);
+                unlockedBlocksCommands.push(['del', config.coin + ':scores:round' + block.height]);
                 unlockedBlocksCommands.push(['zrem', config.coin + ':blocks:candidates', block.serialized]);
                 unlockedBlocksCommands.push(['zadd', config.coin + ':blocks:matured', block.height, [
                     block.hash,
@@ -204,13 +207,13 @@ function runInterval(){
 
                 log('info', logSystem, 'Unlocked %d block with reward %d and donation fee %d. Miners reward: %d', [block.height, block.reward, feePercent, reward]);
 
-                if (block.workerShares) {
-                    var totalShares = parseInt(block.shares);
-                    Object.keys(block.workerShares).forEach(function (worker) {
-                        var percent = block.workerShares[worker] / totalShares;
+                if (block.workerScores) {
+                    var totalScore = parseFloat(block.score);
+                    Object.keys(block.workerScores).forEach(function (worker) {
+                        var percent = block.workerScores[worker] / totalScore;
                         var workerReward = Math.round(reward * percent);
                         payments[worker] = (payments[worker] || 0) + workerReward;
-                        log('info', logSystem, 'Block %d payment to %s for %d of %d shares (%d%%): %d', [block.height, worker, block.workerShares[worker], totalShares, percent, payments[worker]]);
+                        log('info', logSystem, 'Block %d payment to %s for %d%% of total block score: %d', [block.height, worker, percent*100, payments[worker]]);
                     });
                 }
 

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -62,9 +62,7 @@ var bannedIPs = {};
 var perIPStats = {};
 
 var slushMiningEnabled = config.poolServer.slushMining && config.poolServer.slushMining.enabled;
-var scoreTime;
-var lastChecked = 0;
-    
+
 if (!config.poolServer.paymentId) config.poolServer.paymentId = {};
 if (!config.poolServer.paymentId.addressSeparator) config.poolServer.paymentId.addressSeparator = "+";
 
@@ -666,28 +664,30 @@ function recordShareData(miner, job, shareDiff, blockCandidate, hashHex, shareTy
     var dateNow = Date.now();
     var dateNowSeconds = dateNow / 1000 | 0;
 
+    var updateScore;
     // Weighting older shares lower than newer ones to prevent pool hopping
-    if (slushMiningEnabled) {                
-        if (lastChecked + config.poolServer.slushMining.lastBlockCheckRate <= dateNowSeconds || lastChecked === 0) {
-            redisClient.hget(config.coin + ':stats', 'lastBlockFound', function(error, result) {
-                if (error) {
-                    log('error', logSystem, 'Unable to determine the timestamp of the last block found');
-                    return;
-                }
-                scoreTime = result / 1000 | 0; //scoreTime could potentially be something else than the beginning of the current round, though this would warrant changes in api.js (and potentially the redis db)
-                lastChecked = dateNowSeconds;
-            });
-        }
-        
-        job.score = job.difficulty * Math.pow(Math.E, ((dateNowSeconds - scoreTime) / config.poolServer.slushMining.weight)); // Score Calculation
-        log('info', logSystem, 'Submitted score ' + job.score + ' with difficulty ' + job.difficulty + ' and the time ' + scoreTime);
+    if (slushMiningEnabled) {
+        // We need to do this via an eval script because we need fetching the last block time and
+        // calculating the score to run in a single transaction (otherwise we could have a race
+        // condition where a block gets discovered between the time we look up lastBlockFound and
+        // insert the score, which would give the miner an erroneously huge proportion on the new block)
+        updateScore = ['eval', `
+            local age = (ARGV[3] - redis.call('hget', KEYS[2], 'lastBlockFound')) / 1000
+            local score = string.format('%.17g', ARGV[2] * math.exp(age / ARGV[4]))
+            redis.call('hincrbyfloat', KEYS[1], ARGV[1], score)
+            return {score, tostring(age)}
+            `,
+            2 /*keys*/, config.coin + ':scores:roundCurrent', config.coin + ':stats',
+            /* args */ miner.login, job.difficulty, Date.now(), config.poolServer.slushMining.weight];
     }
     else {
         job.score = job.difficulty;
+        updateScore = ['hincrbyfloat', config.coin + ':scores:roundCurrent', miner.login, job.score]
     }
-    
+
     var redisCommands = [
-        ['hincrby', config.coin + ':shares:roundCurrent', miner.login, job.score],
+        updateScore,
+        ['hincrby', config.coin + ':shares_actual:roundCurrent', miner.login, job.difficulty],
         ['zadd', config.coin + ':hashrate', dateNowSeconds, [job.difficulty, miner.login, dateNow].join(':')],
         ['hincrby', config.coin + ':workers:' + miner.login, 'hashes', job.difficulty],
         ['hset', config.coin + ':workers:' + miner.login, 'lastShare', dateNowSeconds],
@@ -704,8 +704,10 @@ function recordShareData(miner, job, shareDiff, blockCandidate, hashHex, shareTy
     
     if (blockCandidate){
         redisCommands.push(['hset', config.coin + ':stats', 'lastBlockFound', Date.now()]);
-        redisCommands.push(['rename', config.coin + ':shares:roundCurrent', config.coin + ':shares:round' + job.height]);
-        redisCommands.push(['hgetall', config.coin + ':shares:round' + job.height]);
+        redisCommands.push(['rename', config.coin + ':scores:roundCurrent', config.coin + ':scores:round' + job.height]);
+        redisCommands.push(['rename', config.coin + ':shares_actual:roundCurrent', config.coin + ':shares_actual:round' + job.height]);
+        redisCommands.push(['hgetall', config.coin + ':scores:round' + job.height]);
+        redisCommands.push(['hgetall', config.coin + ':shares_actual:round' + job.height]);
     }
 
     redisClient.multi(redisCommands).exec(function(err, replies){
@@ -713,8 +715,19 @@ function recordShareData(miner, job, shareDiff, blockCandidate, hashHex, shareTy
             log('error', logSystem, 'Failed to insert share data into redis %j \n %j', [err, redisCommands]);
             return;
         }
+
+        if (slushMiningEnabled) {
+            job.score = parseFloat(replies[0][0]);
+            let age = parseFloat(replies[0][1])
+            log('info', logSystem, 'Submitted score ' + job.score + ' for difficulty ' + job.difficulty + ' and round age ' + age + 's');
+        }
+
         if (blockCandidate){
+            var workerScores = replies[replies.length - 2];
             var workerShares = replies[replies.length - 1];
+            var totalScore = Object.keys(workerScores).reduce(function(p, c){
+                return p + parseFloat(workerScores[c])
+            }, 0);
             var totalShares = Object.keys(workerShares).reduce(function(p, c){
                 return p + parseInt(workerShares[c])
             }, 0);
@@ -722,7 +735,8 @@ function recordShareData(miner, job, shareDiff, blockCandidate, hashHex, shareTy
                 hashHex,
                 Date.now() / 1000 | 0,
                 blockTemplate.difficulty,
-                totalShares
+                totalShares,
+                totalScore
             ].join(':'), function(err, result){
                 if (err){
                     log('error', logSystem, 'Failed inserting block candidate %s \n %j', [hashHex, err]);

--- a/website_example/js/common.js
+++ b/website_example/js/common.js
@@ -202,7 +202,7 @@ function getReadableHashRateString(hashrate){
     if (!hashrate) hashrate = 0;
 
     var i = 0;
-    var byteUnits = [' H', ' KH', ' MH', ' GH', ' TH', ' PH' ];
+    var byteUnits = [' H', ' kH', ' MH', ' GH', ' TH', ' PH' ];
     if (hashrate > 0) {
         while (hashrate > 1000){
             hashrate = hashrate / 1000;
@@ -238,25 +238,7 @@ function formatDifficulty(x) {
 
 // Format luck / current effort
 function formatLuck(difficulty, shares) {
-    // Only an approximation to reverse the calculations done in pool.js, because the shares with their respective times are not recorded in redis
-    // Approximation assumes equal pool hashrate for the whole round
-    // Could potentially be replaced by storing the sum of all job.difficulty in the redis db.
-    if (lastStats.config.slushMiningEnabled) {
-        // Uses integral calculus to calculate the average of a dynamic function
-        var accurateShares = 1/lastStats.config.blockTime * (  // 1/blockTime to get the average
-            shares * lastStats.config.weight * (                  // Basically calculates the 'area below the graph' between 0 and blockTime
-                1 - Math.pow( 
-                    Math.E, 
-                    ((- lastStats.config.blockTime) / lastStats.config.weight)  // blockTime is equal to the highest possible result of (dateNowSeconds - scoreTime)
-                )
-            )
-        );
-    }
-    else {
-        var accurateShares = shares;
-    }
-        
-    var percent = Math.round(accurateShares / difficulty * 100);
+    var percent = Math.round(shares / difficulty * 100);
     if(!percent){
         return '<span class="luckGood">?</span>';
     }

--- a/website_example/pages/admin/statistics.html
+++ b/website_example/pages/admin/statistics.html
@@ -112,25 +112,7 @@
 <!-- Javascript -->
 <script>
 function formatLuck(difficulty, shares) {
-    // Only an approximation to reverse the calculations done in pool.js, because the shares with their respective times are not recorded in redis
-    // Approximation assumes equal pool hashrate for the whole round
-    // Could potentially be replaced by storing the sum of all job.difficulty in the redis db.
-    if (lastStats.config.slushMiningEnabled) {
-        // Uses integral calculus to calculate the average of a dynamic function
-        var accurateShares = 1/lastStats.config.blockTime * (  // 1/blockTime to get the average
-            shares * lastStats.config.weight * (                  // Basically calculates the 'area below the graph' between 0 and blockTime
-                1 - Math.pow( 
-                    Math.E, 
-                    ((- lastStats.config.blockTime) / lastStats.config.weight)  // blockTime is equal to the highest possible result of (dateNowSeconds - scoreTime)
-                )
-            )
-        );
-    }
-    else {
-        var accurateShares = shares;
-    }
-	    
-    var percent = Math.round(accurateShares / difficulty * 100);
+    var percent = Math.round(shares / difficulty * 100);
     if(!percent){
         return '<span class="luckGood">?</span>';
     }

--- a/website_example/pages/payments.html
+++ b/website_example/pages/payments.html
@@ -52,6 +52,22 @@
             </div>
         </div>
     </div>
+
+    <!-- Payment mechanism -->
+    <div class="col-sm-12" id="slush_description">
+        <div class="slushInfo hoverExpandEffect">
+            <div class="text"><span>Payment system</span></div>
+            <div class="content clearfix">
+                <div class="value"><p>This pool uses the "Score" payment system, under which later
+                  shares submitted by miners receive more weight in determining the miner's reward than earlier shares.
+
+                    <p>For more details (including the specific mathematics involved) see the <a
+                     href="https://slushpool.com/help/manual/rewards">slushpool reward
+                     description</a>.</p>
+                </div>
+            </div>
+        </div>
+    </div>
     
 </div>
 
@@ -93,6 +109,8 @@ currentPage = {
         updateText('paymentsInterval', getReadableTime(lastStats.config.paymentsInterval));
         updateText('paymentsMinimum', getReadableCoins(lastStats.config.minPaymentThreshold));
         updateText('paymentsDenomination', getReadableCoins(lastStats.config.denominationUnit, 3));
+        if (!lastStats.config.slushMiningEnabled)
+            $('#slush_description').hide()
         renderPayments(lastStats.pool.payments);
     }
 };

--- a/website_example/pages/worker_stats.html
+++ b/website_example/pages/worker_stats.html
@@ -35,6 +35,8 @@
             <div class="col-sm-6 stats push-up-10">
                 <div><i class="fa fa-bank"></i> <span tkey="pendingBalance">Pending Balance</span>: <span id="yourPendingBalance"></span></div>
                 <div><i class="fa fa-money"></i> <span tkey="totalPaid">Total Paid</span>: <span id="yourPaid"></span></div>
+                <div><i class="fa fa-star"></i> <span>Round contribution</span>: <span id="yourRoundShareProportion"></span>%
+                    <span id="slush_round_info"> (shares), <span id="yourRoundScoreProportion"></span>% (<a target="_blank" href="#payments">score</a>)</span></span></div>
                 <div><i class="fa fa-money"></i> <span tkey="payoutEstimate">Current Payout Estimate</span>: <span id="yourPayoutEstimate"></span></div>
             </div>
             <div class="col-sm-6 userChart">
@@ -161,6 +163,8 @@ function fetchAddressStats(longpoll){
 
             var userRoundHashes = parseInt(data.stats.roundHashes || 0);
             var poolRoundHashes = parseInt(lastStats.pool.roundHashes || 0);
+            var userRoundScore = parseFloat(data.stats.roundScore || 0);
+            var poolRoundScore = parseFloat(lastStats.pool.roundScore || 0);
             var lastReward = parseFloat(lastStats.lastblock.reward || 0);
 	    
             var poolFee = lastStats.config.fee;
@@ -173,8 +177,15 @@ function fetchAddressStats(longpoll){
             }
 	    var transferFee = lastStats.config.transferFee;
 	    
-            var payoutEstimatePct = parseFloat(userRoundHashes * 100 / poolRoundHashes)
-	    var payoutEstimate = Math.round(lastReward * (payoutEstimatePct / 100));
+            var share_pct = userRoundHashes * 100 / poolRoundHashes;
+            var score_pct = userRoundScore * 100 / poolRoundScore;
+            updateText('yourRoundShareProportion', Math.round(share_pct * 1000) / 1000);
+            updateText('yourRoundScoreProportion', Math.round(score_pct * 1000) / 1000);
+            if (!lastStats.config.slushMiningEnabled) {
+                $('#slush_round_info').hide();
+            }
+
+            var payoutEstimate = Math.round(lastReward * (score_pct / 100));
             if (transferFee) payoutEstimate = payoutEstimate - transferFee;
 	    if (payoutEstimate < 0) payoutEstimate = 0;
 	    updateText('yourPayoutEstimate', getReadableCoins(payoutEstimate));

--- a/website_example/themes/default.css
+++ b/website_example/themes/default.css
@@ -546,6 +546,37 @@ table th.sort:hover{
   font-weight: normal;
 }
 
+/* Slush payment info box */
+.slushInfo {
+  background-color: #014e71;
+  box-shadow: 0 1px 4px 0 rgba(0, 0, 0, 0.14);
+  cursor: default;
+  padding: 15px;
+  border-radius: 3px;
+  color: #fff;
+  margin-bottom: 30px;
+}
+.slushInfo .text {
+  font-size: 13px;
+  color: #fff;
+  text-transform: uppercase;
+}
+@media (max-width: 767px){
+  .slushInfo {
+    margin-bottom: 15px;
+  }
+}
+.slushInfo .content .value {
+  float: left;
+  font-size: 16px;
+  font-weight: 400;
+  color: #fff;
+  padding: 8px 8px 0 0;
+}
+.slushInfo .content .value a {
+    color: #fff;
+}
+
 /* Pool Statistics */
 .stats > div:not(#addressError) {
   color: #262626; 


### PR DESCRIPTION
A NiceHash pool hopper decided to grace my pool with his presence recently, so I looked into the pool's slush mining support.  I found a couple bugs and some limitations that I fixed/improved:

- when slush mining was enabled actual shares were only estimated; this commit splits up the scores and shares values so that accurate shares can still be reported.

- when an orphan was found during unlocking, the shares (i.e. score) of miners was re-added to the current score.  This is just plain wrong under slush mining (it's kind of weird under prop mining too) since it's transplating shares 2 hours into the future.  This isn't great under prop, but can be a disaster under slush (particularly when the orphaned block took exceptionally long since the orphaned scores will dominate the current block scores).  This one could probably be fixed by rescaling the scores of the orphaned block by `exp((τ - t) / λ)`, where `τ` is the orphaned block's start time and `t` is the new block's start time, but since that is pretty much guaranteed to be a number very close to 0 (since this is happening when unlocking, i.e. 2 hours later) it's not going to do much, so I just skipped replanting the shares entirely under score payments.

- Slush scores can easily exceed the limits of an int; store them as floats instead so that we don't have to worry about such an overflow.

- The recorded share data had a serious bug where it could end up recording infinite for a worker's share: the code requested the last block time, but didn't wait for the response before using it, which would result in a division by 0, thus inserting infinity for a user's score.  This is bad (every reward is going to come out as 0 or NaN).

- To deal with the above, the slush calculation is now done using a lua command (i.e. a redis `EVAL`) to do the last block lookup in the same transaction as the score insertion.  This crucially also avoids a race condition: if a block is discovered between the time of the last block time lookup and the score insertion the score would be far too high and dominate the block (at least until the new block reached the same age as the old block).

- The above also eliminates the need for last-block-time polling for score entirely: it isn't needed at all now since the lua eval gets the value, calculates the exponential score, and increments the share atomically.

- Scores/shares are now included in the API and reported on the worker stats page.

- Added a blurb to the Payments page describing the payment mechanism.

- remove blockTime integral calculation approximations from javascript; they were fairly inaccurate (particularly in the face of pool hashrate fluctuations) -- and more importantly the actual shares are available now.