### PR TITLE
Clear old `shares_actual` entries.

### DIFF
--- a/lib/blockUnlocker.js
+++ b/lib/blockUnlocker.js
@@ -130,6 +130,7 @@ function runInterval(){
                 if (!block.orphaned) return;
 
                 orphanCommands.push(['del', config.coin + ':scores:round' + block.height]);
+                orphanCommands.push(['del', config.coin + ':shares_actual:round' + block.height]);
 
                 orphanCommands.push(['zrem', config.coin + ':blocks:candidates', block.serialized]);
                 orphanCommands.push(['zadd', config.coin + ':blocks:matured', block.height, [
@@ -182,6 +183,7 @@ function runInterval(){
                 totalBlocksUnlocked++;
 
                 unlockedBlocksCommands.push(['del', config.coin + ':scores:round' + block.height]);
+                unlockedBlocksCommands.push(['del', config.coin + ':shares_actual:round' + block.height]);
                 unlockedBlocksCommands.push(['zrem', config.coin + ':blocks:candidates', block.serialized]);
                 unlockedBlocksCommands.push(['zadd', config.coin + ':blocks:matured', block.height, [
                     block.hash,


### PR DESCRIPTION
Only scores were being cleared when a block is unlocked or orphaned, but the actual shares submitted needs to be cleaned up as well.