### PR TITLE
Use payment.hash as a unique ID for payment rows

### DIFF
--- a/website_example/pages/payments.html
+++ b/website_example/pages/payments.html
@@ -143,7 +143,7 @@ function getPaymentRowElement(payment, jsonString){
     var row = document.createElement('tr');
     row.setAttribute('data-json', jsonString);
     row.setAttribute('data-time', payment.time);
-    row.setAttribute('id', 'paymentRow' + payment.time);
+    row.setAttribute('id', 'paymentRow' + payment.hash);
 
     row.innerHTML = getPaymentCells(payment);
 
@@ -156,7 +156,7 @@ function renderPayments(paymentsResults){
     for (var i = 0; i < paymentsResults.length; i += 2){
         var payment = parsePayment(paymentsResults[i + 1], paymentsResults[i]);
         var paymentJson = JSON.stringify(payment);
-        var existingRow = document.getElementById('paymentRow' + payment.time);
+        var existingRow = document.getElementById('paymentRow' + payment.hash);
 
         if (existingRow && existingRow.getAttribute('data-json') !== paymentJson){
             $(existingRow).replaceWith(getPaymentRowElement(payment, paymentJson));


### PR DESCRIPTION
Currently **payment.time** is used as a unique ID for payment table rows. This could be an issue if multiple payments has exactly same timestamps (highly unlikely but possible) as only 1 payment, out of all the payments with same timestamps will be shown. 

Using **payment.hash** as table row ID will ensure that all the rows has a unique ID and would prevent issues that come with multiple payments with same timestamps.