### PR TITLE
Add 1/6/24-hour average hashrate stats

### DIFF
--- a/config_examples/alloy.json
+++ b/config_examples/alloy.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/arqma.json
+++ b/config_examples/arqma.json
@@ -297,6 +297,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/bbscoin.json
+++ b/config_examples/bbscoin.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/bytecoin.json
+++ b/config_examples/bytecoin.json
@@ -298,6 +298,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/croat.json
+++ b/config_examples/croat.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/dero.json
+++ b/config_examples/dero.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/digitalnote.json
+++ b/config_examples/digitalnote.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/electroneum.json
+++ b/config_examples/electroneum.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/festival.json
+++ b/config_examples/festival.json
@@ -293,6 +293,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/graft.json
+++ b/config_examples/graft.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/haven.json
+++ b/config_examples/haven.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/intensecoin.json
+++ b/config_examples/intensecoin.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/intucoin.json
+++ b/config_examples/intucoin.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/iridium.json
+++ b/config_examples/iridium.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/italocoin.json
+++ b/config_examples/italocoin.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/loki.json
+++ b/config_examples/loki.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/masari.json
+++ b/config_examples/masari.json
@@ -294,6 +294,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/monero.json
+++ b/config_examples/monero.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/myztic.json
+++ b/config_examples/myztic.json
@@ -299,6 +299,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/qwertycoin.json
+++ b/config_examples/qwertycoin.json
@@ -298,6 +298,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/stellite.json
+++ b/config_examples/stellite.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/sumokoin.json
+++ b/config_examples/sumokoin.json
@@ -300,6 +300,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/config_examples/superior.json
+++ b/config_examples/superior.json
@@ -299,6 +299,12 @@
                 "stepInterval": 1800,
                 "maximumPeriod": 86400
             },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
             "payments": {
                 "enabled": true
             }

--- a/lib/api.js
+++ b/lib/api.js
@@ -110,12 +110,18 @@ function handleServerRequest(request, response) {
             handleSetTelegramNotifications(urlParts, response);
             break;
      
-        // Miners hashrate (used for charts)
+        // Miners/workers hashrate (used for charts)
         case '/miners_hashrate':
             if (!authorize(request, response)) {
                 return;
             }
             handleGetMinersHashrate(response);
+            break;
+        case '/workers_hashrate':
+            if (!authorize(request, response)) {
+                return;
+            }
+            handleGetWorkersHashrate(response);
             break;
 
         // Pool Administration
@@ -526,13 +532,35 @@ function broadcastLiveStats(){
 }
 
 /**
+ * Takes a chart data JSON string and uses it to compute the average over the past hour, 6 hours,
+ * and 24 hours.  Returns [AVG1, AVG6, AVG24].
+ **/
+function extractAverageHashrates(chartdata) {
+    var now = new Date() / 1000 | 0;
+
+    var sums = [0, 0, 0]; // 1h, 6h, 24h
+    var counts = [0, 0, 0];
+
+    var sets = JSON.parse(chartdata); // [time, avgValue, updateCount]
+    for (let j in sets) {
+        var hr = sets[j][1];
+        if (now - sets[j][0] <=  1*60*60) { sums[0] += hr; counts[0]++; }
+        if (now - sets[j][0] <=  6*60*60) { sums[1] += hr; counts[1]++; }
+        if (now - sets[j][0] <= 24*60*60) { sums[2] += hr; counts[2]++; }
+    }
+
+    return [sums[0] * 1.0 / (counts[0] || 1), sums[1] * 1.0 / (counts[1] || 1), sums[2] * 1.0 / (counts[2] || 1)];
+}
+
+/**
  * Broadcast worker statistics
  **/
 function broadcastWorkerStats(address, destinations) {
     var redisCommands = [
         ['hgetall', config.coin + ':workers:' + address],
         ['zrevrange', config.coin + ':payments:' + address, 0, config.api.payments - 1, 'WITHSCORES'],
-        ['keys', config.coin + ':unique_workers:' + address + '~*']
+        ['keys', config.coin + ':unique_workers:' + address + '~*'],
+        ['get', config.coin + ':charts:hashrate:' + address]
     ];
     redisClient.multi(redisCommands).exec(function(error, replies){
         if (error || !replies || !replies[0]){
@@ -544,6 +572,12 @@ function broadcastWorkerStats(address, destinations) {
         stats.hashrate = minerStats[address] && minerStats[address]['hashrate'] ? minerStats[address]['hashrate'] : 0;
         stats.roundScore = minerStats[address] && minerStats[address]['roundScore'] ? minerStats[address]['roundScore'] : 0;
         stats.roundHashes = minerStats[address] && minerStats[address]['roundHashes'] ? minerStats[address]['roundHashes'] : 0;
+        if (replies[3]) {
+            var hr_avg = extractAverageHashrates(replies[3]);
+            stats.hashrate_1h  = hr_avg[0];
+            stats.hashrate_6h  = hr_avg[1];
+            stats.hashrate_24h = hr_avg[2];
+        }
 
         var paymentsData = replies[1];
       
@@ -566,12 +600,22 @@ function broadcastWorkerStats(address, destinations) {
             var redisCommands = [];
             for (var i in workersData){
                 redisCommands.push(['hgetall', config.coin + ':unique_workers:' + address + '~' + workersData[i].name]);
+                redisCommands.push(['get', config.coin + ':charts:worker_hashrate:' + address + '~' + workersData[i].name]);
             }
             redisClient.multi(redisCommands).exec(function(error, replies){
                 for (var i in workersData) {
-                    if (!replies[i]) continue;
-                    workersData[i].lastShare = replies[i]['lastShare'] ? parseInt(replies[i]['lastShare']) : 0;
-                    workersData[i].hashes = replies[i]['hashes'] ? parseInt(replies[i]['hashes']) : 0;
+                    var wi = 2*i;
+                    var hi = wi + 1
+                    if (replies[wi]) {
+                        workersData[i].lastShare = replies[wi]['lastShare'] ? parseInt(replies[wi]['lastShare']) : 0;
+                        workersData[i].hashes = replies[wi]['hashes'] ? parseInt(replies[wi]['hashes']) : 0;
+                    }
+                    if (replies[hi]) {
+                        var avgs = extractAverageHashrates(replies[hi]);
+                        workersData[i]['hashrate_1h']  = avgs[0];
+                        workersData[i]['hashrate_6h']  = avgs[1];
+                        workersData[i]['hashrate_24h']  = avgs[2];
+                    }
                 }
 
                 var data = {
@@ -661,7 +705,8 @@ function handleMinerStats(urlParts, response){
         redisClient.multi([
             ['hgetall', config.coin + ':workers:' + address],
             ['zrevrange', config.coin + ':payments:' + address, 0, config.api.payments - 1, 'WITHSCORES'],
-            ['keys', config.coin + ':unique_workers:' + address + '~*']
+            ['keys', config.coin + ':unique_workers:' + address + '~*'],
+            ['get', config.coin + ':charts:hashrate:' + address]
         ]).exec(function(error, replies){
             if (error || !replies[0]){
                 var dataJSON = JSON.stringify({error: 'Not found'});
@@ -679,6 +724,12 @@ function handleMinerStats(urlParts, response){
             stats.hashrate = minerStats[address] && minerStats[address]['hashrate'] ? minerStats[address]['hashrate'] : 0;
             stats.roundScore = minerStats[address] && minerStats[address]['roundScore'] ? minerStats[address]['roundScore'] : 0;
             stats.roundHashes = minerStats[address] && minerStats[address]['roundHashes'] ? minerStats[address]['roundHashes'] : 0;
+            if (replies[3]) {
+                var hr_avg = extractAverageHashrates(replies[3]);
+                stats.hashrate_1h  = hr_avg[0];
+                stats.hashrate_6h  = hr_avg[1];
+                stats.hashrate_24h = hr_avg[2];
+            }
 
             var paymentsData = replies[1];
 
@@ -701,12 +752,22 @@ function handleMinerStats(urlParts, response){
                 var redisCommands = [];
                 for (var i in workersData){
                     redisCommands.push(['hgetall', config.coin + ':unique_workers:' + address + '~' + workersData[i].name]);
+                    redisCommands.push(['get', config.coin + ':charts:worker_hashrate:' + address + '~' + workersData[i].name]);
                 }
                 redisClient.multi(redisCommands).exec(function(error, replies){
                     for (var i in workersData){
-                        if (!replies[i]) continue;
-                        workersData[i].lastShare = replies[i]['lastShare'] ? parseInt(replies[i]['lastShare']) : 0;
-                        workersData[i].hashes = replies[i]['hashes'] ? parseInt(replies[i]['hashes']) : 0;
+                        var wi = 2*i;
+                        var hi = wi + 1
+                        if (replies[wi]) {
+                            workersData[i].lastShare = replies[wi]['lastShare'] ? parseInt(replies[wi]['lastShare']) : 0;
+                            workersData[i].hashes = replies[wi]['hashes'] ? parseInt(replies[wi]['hashes']) : 0;
+                        }
+                        if (replies[hi]) {
+                            var avgs = extractAverageHashrates(replies[hi]);
+                            workersData[i]['hashrate_1h']  = avgs[0];
+                            workersData[i]['hashrate_6h']  = avgs[1];
+                            workersData[i]['hashrate_24h']  = avgs[2];
+                        }
                     }
             
                     var data = {
@@ -1293,6 +1354,30 @@ function handleGetMinersHashrate(response) {
     });
     response.end(reply);
 }
+
+/**
+ * Return workers hashrate
+ **/
+function handleGetWorkersHashrate(response) {
+    var data = {};
+    for (var miner in minersHashrate){
+        if (miner.indexOf('~') === -1) continue;
+        data[miner] = minersHashrate[miner];
+    }
+
+    var reply = JSON.stringify({
+        workersHashrate: data
+    });
+
+    response.writeHead("200", {
+        'Access-Control-Allow-Origin': '*',
+        'Cache-Control': 'no-cache',
+        'Content-Type': 'application/json',
+        'Content-Length': reply.length
+    });
+    response.end(reply);
+}
+
 
 /**
  * Authorize access to a secured API call

--- a/lib/charts.js
+++ b/lib/charts.js
@@ -41,6 +41,13 @@ function startDataCollectors() {
             collectUsersHashrate('hashrate', settings);
         }, settings.updateInterval * 1000)
     }
+
+    settings = config.charts.user.worker_hashrate;
+    if (settings && settings.enabled) {
+        setInterval(function() {
+            collectWorkersHashrate('worker_hashrate', settings);
+        }, settings.updateInterval * 1000);
+    }
 }
 
 // Chart data functions
@@ -203,6 +210,19 @@ function getUsersHashrates(callback) {
 }
 
 /**
+ * Get workers' hashrates from API
+ **/
+function getWorkersHashrates(callback) {
+    apiInterfaces.pool('/workers_hashrate', function(error, data) {
+        if (error) {
+            log('error', logSystem, 'Unable to get API data for workers_hashrate: ' + error);
+        }
+        var resultData = data && data.workersHashrate ? data.workersHashrate : {};
+        callback(resultData);
+    });
+}
+
+/**
  * Collect users hashrate from API
  **/
 function collectUsersHashrate(chartName, settings) {
@@ -210,7 +230,7 @@ function collectUsersHashrate(chartName, settings) {
     redisClient.keys(redisBaseKey + '*', function(keys) {
         var hashrates = {};
         for(var i in keys) {
-            hashrates[keys[i].substr(keys[i].length)] = 0;
+            hashrates[keys[i].substr(redisBaseKey.length)] = 0;
         }
         getUsersHashrates(function(newHashrates) {
             for(var address in newHashrates) {
@@ -226,6 +246,25 @@ function collectUsersHashrate(chartName, settings) {
  **/
 function getUserHashrateChartData(address, callback) {
     getChartDataFromRedis('hashrate:' + address, callback);
+}
+
+/**
+ * Collect worker hashrates from API
+ **/
+function collectWorkersHashrate(chartName, settings) {
+    var redisBaseKey = getStatsRedisKey(chartName) + ':';
+    redisClient.keys(redisBaseKey + '*', function(keys) {
+        var hashrates = {};
+        for(var i in keys) {
+            hashrates[keys[i].substr(redisBaseKey.length)] = 0;
+        }
+        getWorkersHashrates(function(newHashrates) {
+            for(var addr_worker in newHashrates) {
+                hashrates[addr_worker] = newHashrates[addr_worker];
+            }
+            storeCollectedValues(chartName, hashrates, settings);
+        });
+    });
 }
 
 /**

--- a/website_example/pages/worker_stats.html
+++ b/website_example/pages/worker_stats.html
@@ -17,6 +17,8 @@
 	<div class="row card">
             <div class="col-sm-6 stats push-up-10">
                 <div><i class="fa fa-tachometer"></i> <span tkey="currentHashRate">Current Hash Rate</span>: <span id="yourHashrateHolder"></span></div>
+                <div id="minerAvgHR"><i class="fa fa-tachometer"></i> <span tkey="averageHashRate">Average 1/6/24-hour Hash Rate</span>:
+                    <span id="yourHR1h"></span> / <span id="yourHR6h"></span> / <span id="yourHR24h"></span></div>
                 <div><i class="fa fa-clock-o"></i> <span tkey="lastShare">Last Share Submitted</span>: <span id="yourLastShare"></span></div>
                 <div><i class="fa fa-cloud-upload"></i> <span tkey="totalHashes">Total Hashes Submitted</span>: <span id="yourHashes"></span></div>
             </div>
@@ -59,8 +61,11 @@
                     <th class="col1 sort"><span tkey="status">Status</span> <i class="fa fa-sort"></i></th>
                     <th class="col2 sort"><span tkey="workerName">Worker Name</span> <i class="fa fa-sort"></i></th>
                     <th class="col3 sort"><span tkey="hashRate">Hash Rate</span> <i class="fa fa-sort"></i></th>
-                    <th class="col4 sort"><span tkey="lastShare">Last Share Submitted</span> <i class="fa fa-sort"></i></th>
-                    <th class="col5 sort"><span tkey="totalHashes">Total Hashes Submitted</span> <i class="fa fa-sort"></i></th>
+                    <th class="col4 sort avghr" title="Average hashrate over the last hour (only includes times the worker was active)"><span tkey="hashRate1h">HR (1h)</span> <i class="fa fa-sort"></i></th>
+                    <th class="col5 sort avghr" title="Average hashrate over the last six hours (only includes times the worker was active)"><span tkey="hashRate6h">HR (6h)</span> <i class="fa fa-sort"></i></th>
+                    <th class="col6 sort avghr" title="Average hashrate over the last day (only includes times the worker was active)"><span tkey="hashRate24h">HR (24h)</span> <i class="fa fa-sort"></i></th>
+                    <th class="col7 sort"><span tkey="lastShare">Last Share Submitted</span> <i class="fa fa-sort"></i></th>
+                    <th class="col8 sort"><span tkey="totalHashes">Total Hashes Submitted</span> <i class="fa fa-sort"></i></th>
                 </tr>
                 </thead>
                 <tbody id="workersReport_rows">
@@ -159,6 +164,14 @@ function fetchAddressStats(longpoll){
             }
 
             updateText('yourHashrateHolder', (getReadableHashRateString(data.stats.hashrate) || '0 H') + '/sec');
+            if ('hashrate_1h' in data.stats) {
+                $('#minerAvgHR').show();
+                updateText('yourHR1h', (getReadableHashRateString(data.stats.hashrate_1h) || '0 H') + '/s');
+                updateText('yourHR6h', (getReadableHashRateString(data.stats.hashrate_6h) || '0 H') + '/s');
+                updateText('yourHR24h', (getReadableHashRateString(data.stats.hashrate_24h) || '0 H') + '/s');
+            } else {
+                $('#minerAvgHR').hide();
+            }
             updateText('yourHashes', (data.stats.hashes || 0).toString());
             updateText('yourPaid', getReadableCoins(data.stats.paid));
             updateText('yourPendingBalance', getReadableCoins(data.stats.balance));
@@ -405,15 +418,21 @@ function getWorkerRowElement(worker, jsonString){
 // Get worker cells
 function getWorkerCells(worker){
     var hashrate = worker.hashrate ? worker.hashrate : 0;
+    var hashrate1h = worker.hashrate_1h || 0;
+    var hashrate6h = worker.hashrate_6h || 0;
+    var hashrate24h = worker.hashrate_24h || 0;
     var lastShare = worker.lastShare ? worker.lastShare : 0;
     var hashes = (worker.hashes || 0).toString();
     var status = (hashrate <= 0) ? 'error' : 'ok';
-    
+
     return '<td class="col1" data-sort="' + status + '"><i class="fa fa-' + (status == 'ok' ? 'check status-ok' : 'times status-error') + '"></i></td>' +
            '<td class="col2" data-sort="' + (worker.name != 'undefined' ? worker.name : '') + '">' + (worker.name != 'undefined' ? worker.name : '<em>Undefined</em>') + '</td>' +
-           '<td class="col3" data-sort="' + hashrate + '">' + getReadableHashRateString(hashrate) + '/sec</td>' +
-           '<td class="col4" data-sort="' + lastShare + '">' + (lastShare ? $.timeago(new Date(parseInt(lastShare) * 1000).toISOString()) : 'Never') + '</td>' +
-           '<td class="col5" data-sort="' + hashes + '">' + hashes + '</td>';
+           '<td class="col3" data-sort="' + hashrate + '">' + getReadableHashRateString(hashrate) + '/s</td>' +
+           '<td class="col4 avghr" data-sort="' + hashrate1h + '">' + getReadableHashRateString(hashrate1h) + '/s</td>' +
+           '<td class="col5 avghr" data-sort="' + hashrate6h + '">' + getReadableHashRateString(hashrate6h) + '/s</td>' +
+           '<td class="col6 avghr" data-sort="' + hashrate24h + '">' + getReadableHashRateString(hashrate24h) + '/s</td>' +
+           '<td class="col7" data-sort="' + lastShare + '">' + (lastShare ? $.timeago(new Date(parseInt(lastShare) * 1000).toISOString()) : 'Never') + '</td>' +
+           '<td class="col8" data-sort="' + hashes + '">' + hashes + '</td>';
 }
 
 // Handle sort on workers table
@@ -439,10 +458,13 @@ function renderWorkers(workersData){
             break;
         }
     }
-    
+
+    var have_avg_hr = false;
+
     for (var i = 0; i < workersData.length; i++){
         var worker = workersData[i];
 	if (Date.now()/1000 - parseInt(worker.lastShare) > 2 * 86400) continue;
+        if (!have_avg_hr && 'hashrate_1h' in worker) have_avg_hr = true;
         var workerJson = JSON.stringify(worker);
         var existingRow = document.getElementById('workerRow_' + getWorkerRowId(worker.name));    
         if (existingRow && existingRow.getAttribute('data-json') !== workerJson){
@@ -453,6 +475,9 @@ function renderWorkers(workersData){
             $workersRows.append(workerElement);
         }
     }
+
+    if (!have_avg_hr) $('#workersReport .avghr').hide();
+    else $('#workersReport .avghr').show();
 }
 
 /**

--- a/website_example/themes/default.css
+++ b/website_example/themes/default.css
@@ -792,13 +792,16 @@ table th.sort:hover{
   #workersReport table .col1 {
     width:80px;
   }
-  #workersReport table .col3 {
-    width:150px;
+  #workersReport table .col3,
+  #workersReport table .col4,
+  #workersReport table .col5,
+  #workersReport table .col6 {
+    width:120px;
   }  
-  #workersReport table .col4 {
+  #workersReport table .col7 {
     width: 210px;
   }
-  #workersReport table .col5 {
+  #workersReport table .col8 {
     width: 210px;
   }
 }


### PR DESCRIPTION
This adds average hashrates collected over the past 1/6/24 hours on a
per-worker and per-miner level.  Per-miner can already be done from the
miner hashrate; per-worker requires adding new chart collection data
for each worker.

To make this work per-worker you need to add:

            "worker_hashrate": {
                "enabled": true,
                "updateInterval": 60,
                "stepInterval": 60,
                "maximumPeriod": 86400
            },

to the "charts" -> "user" section of the coin configuration.