### PR TITLE
Fix telegram crash when requesting report for invalid addr

### DIFF
--- a/lib/telegramBot.js
+++ b/lib/telegramBot.js
@@ -178,7 +178,10 @@ function sendMinerStats(telegramMsg, address) {
     apiInterfaces.pool('/stats_address?address='+address, function(error, data) {
         if (error || !data) {
             log('error', logSystem, 'Unable to get API data for miner stats: ' + error);
-            return bot.sendMessage(id, 'Unable to get miner statistics. Please retry.');
+            return bot.sendMessage(telegramMsg.from.id, 'Unable to get miner statistics. Please retry.');
+        }
+        if (!data.stats) {
+            return bot.sendMessage(telegramMsg.from.id, 'No miner statistics found for that address. Please check the address and try again.');
         }
 
         var minerHashrate = utils.getReadableHashRate(data.stats.hashrate);


### PR DESCRIPTION
If attempting to request a report for a miner that doesn't exist on the
pool the telegram bot crashes (`data.stats` is undefined, leading to an
exception when calling `data.stats.hashrate`).

This adds a new "not found" error message if the lookup doesn't return
any stats.

Additionally this fixes an error in the event of a harder lookup failure
(e.g. from an error connecting to the api) not using the correct
variable for the recipient.