### PR TITLE
Workaround load balancers / Docker Swarm

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,23 @@
+# Why node:8 and not node:10? Because (a) v8 is LTS, so more likely to be stable, and (b) "npm update" on node:10 breaks on Docker on Linux (but not on OSX, oddly)
+FROM node:8-slim
+
+RUN apt-get update \
+  && DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs-legacy npm git libboost1.55-all libssl-dev \
+  && rm -rf /var/lib/apt/lists/* && \
+  chmod +x /wait-for-it.sh
+
+ADD . /pool/
+WORKDIR /pool/
+
+RUN npm update
+
+RUN mkdir -p /config
+
+EXPOSE 8117
+EXPOSE 3333
+EXPOSE 5555
+EXPOSE 7777
+
+VOLUME ["/config"]
+
+CMD node init.js -config=/config/config.json

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,8 +3,7 @@ FROM node:8-slim
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs-legacy npm git libboost1.55-all libssl-dev \
-  && rm -rf /var/lib/apt/lists/* && \
-  chmod +x /wait-for-it.sh
+  && rm -rf /var/lib/apt/lists/* 
 
 ADD . /pool/
 WORKDIR /pool/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
-# Why node:8 and not node:10? Because (a) v8 is LTS, so more likely to be stable, and (b) "npm update" on node:10 breaks on Docker on Linux (but not on OSX, oddly)
-FROM node:8-slim
+# Why node:9 and not node:10? Because (a) v8 is LTS, so more likely to be stable, and (b) "npm update" on node:10 breaks on Docker on Linux (but not on OSX, oddly)
+FROM node:9-slim
 
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive apt-get install -y nodejs-legacy npm git libboost1.55-all libssl-dev \

--- a/README.md
+++ b/README.md
@@ -382,6 +382,7 @@ Explanation for each field:
     "sslKey": "./privkey.pem", // The SSL private key
     "sslCA": "./chain.pem", // The SSL certificate authority chain
     "trustProxyIP": false // Proxy X-Forwarded-For support
+    "ignoreSrcIP": false // Silently ignore source IP when changing min payments, or notification settings
 },
 
 /* Coin daemon connection details (default port is 18981) */

--- a/config_examples/turtlecoin.json
+++ b/config_examples/turtlecoin.json
@@ -1,0 +1,314 @@
+{
+    "poolHost": "your.poolhost.tld",
+
+    "coin": "turtlecoin",
+    "symbol": "TRTL",
+    "coinUnits": 100,
+    "coinDecimalPlaces": 2,
+    "coinDifficultyTarget": 30,
+
+    "daemonType": "bytecoin",
+    "cnAlgorithm": "cryptonight_light",
+    "cnVariant": 1,
+    "cnBlobType": 2,
+
+    "logging": {
+        "files": {
+            "level": "info",
+            "directory": "logs",
+            "flushInterval": 5
+        },
+        "console": {
+            "level": "info",
+            "colors": true
+        }
+    },
+
+    "poolServer": {
+        "enabled": true,
+        "clusterForks": "auto",
+        "poolAddress": "**Your Pool Wallet Address**",
+        "intAddressPrefix": null,
+        "blockRefreshInterval": 1000,
+        "minerTimeout": 900,
+        "sslCert": "./cert.pem",
+        "sslKey": "./privkey.pem",
+        "sslCA": "./chain.pem",
+        "ports": [
+            {
+                "port": 3333,
+                "difficulty": 5000,
+                "desc": "Low end hardware"
+            },
+            {
+                "port": 4444,
+                "difficulty": 15000,
+                "desc": "Mid range hardware"
+            },
+            {
+                "port": 5555,
+                "difficulty": 25000,
+                "desc": "High end hardware"
+            },
+            {
+                "port": 7777,
+                "difficulty": 500000,
+                "desc": "Cloud-mining / NiceHash"
+            }
+            {
+                "port": 8888,
+                "difficulty": 25000,
+                "desc": "Hidden port",
+                "hidden": true
+            },
+            {
+                "port": 9999,
+                "difficulty": 20000,
+                "desc": "SSL connection",
+                "ssl": true
+            }
+        ],
+        "varDiff": {
+            "minDiff": 100,
+            "maxDiff": 500000,
+            "targetTime": 10,
+            "retargetTime": 30,
+            "variancePercent": 30,
+            "maxJump": 100
+        },
+        "paymentId": {
+            "addressSeparator": "."
+        },
+        "fixedDiff": {
+            "enabled": true,
+            "addressSeparator": "+"
+        },
+        "shareTrust": {
+            "enabled": true,
+            "min": 10,
+            "stepDown": 3,
+            "threshold": 10,
+            "penalty": 30
+        },
+        "banning": {
+            "enabled": true,
+            "time": 600,
+            "invalidPercent": 25,
+            "checkThreshold": 30
+        },
+        "slushMining": {
+            "enabled": false,
+            "weight": 300,
+            "blockTime": 60,
+            "lastBlockCheckRate": 1
+         }
+    },
+
+    "payments": {
+        "enabled": true,
+        "interval": 600,
+        "maxAddresses": 50,
+        "mixin": 3,
+        "priority": 0,
+        "transferFee": 10000,
+        "dynamicTransferFee": true,
+        "minerPayFee" : true,
+        "minPayment": 500000,
+        "maxPayment": null,
+        "maxTransactionAmount": 0,
+        "denomination": 100
+    },
+
+    "blockUnlocker": {
+        "enabled": true,
+        "interval": 30,
+        "depth": 10,
+        "poolFee": 100,
+        "devDonation": 0.0,
+        "networkFee": 0.0
+    },
+
+    "api": {
+        "enabled": true,
+        "hashrateWindow": 600,
+        "updateInterval": 5,
+        "bindIp": "0.0.0.0",
+        "port": 8117,
+        "blocks": 30,
+        "payments": 30,
+        "host": "api",
+        "password": "CHANGE ME",
+        "ssl": false,
+        "sslPort": 8119,
+        "sslCert": "./cert.pem",
+        "sslKey": "./privkey.pem",
+        "sslCA": "./chain.pem",
+        "trustProxyIP": true
+    },
+
+    "daemon": {
+        "host": "127.0.0.1",
+        "port": 11898
+    },
+
+    "wallet": {
+        "host": "127.0.0.1",
+        "port": 8070,
+	"password": "**YOUR WALLET RPC PASSWORD - REQUIRES PR#305 **"
+    },
+
+    "redis": {
+        "host": "redis",
+        "port": 6379,
+        "auth": null,
+        "db": 0,
+	"cleanupInterval": 15
+    },
+
+    "notifications": {
+        "emailTemplate": "email_templates/default.txt",
+        "emailSubject": {
+            "emailAdded": "Your email was registered",
+            "workerConnected": "Worker %WORKER_NAME% connected",
+            "workerTimeout": "Worker %WORKER_NAME% stopped hashing",
+            "workerBanned": "Worker %WORKER_NAME% banned",
+            "blockFound": "Block %HEIGHT% found !",
+            "blockUnlocked": "Block %HEIGHT% unlocked !",
+            "blockOrphaned": "Block %HEIGHT% orphaned !",
+            "payment": "We sent you a payment !"
+        },
+        "emailMessage": {
+            "emailAdded": "Your email has been registered to receive pool notifications.",
+            "workerConnected": "Your worker %WORKER_NAME% for address %MINER% is now connected from ip %IP%.",
+            "workerTimeout": "Your worker %WORKER_NAME% for address %MINER% has stopped submitting hashes on %LAST_HASH%.",
+            "workerBanned": "Your worker %WORKER_NAME% for address %MINER% has been banned.",
+            "blockFound": "Block found at height %HEIGHT% by miner %MINER% on %TIME%. Waiting maturity.",
+            "blockUnlocked": "Block mined at height %HEIGHT% with %REWARD% and %EFFORT% effort on %TIME%.",
+            "blockOrphaned": "Block orphaned at height %HEIGHT% :(",
+            "payment": "A payment of %AMOUNT% has been sent to %ADDRESS% wallet."
+        },
+        "telegramMessage": {
+            "workerConnected": "Your worker _%WORKER_NAME%_ for address _%MINER%_ is now connected from ip _%IP%_.",
+            "workerTimeout": "Your worker _%WORKER_NAME%_ for address _%MINER%_ has stopped submitting hashes on _%LAST_HASH%_.",
+            "workerBanned": "Your worker _%WORKER_NAME%_ for address _%MINER%_ has been banned.",
+            "blockFound": "*Block found at height* _%HEIGHT%_ *by miner* _%MINER%_*! Waiting maturity.*",
+            "blockUnlocked": "*Block mined at height* _%HEIGHT%_ *with* _%REWARD%_ *and* _%EFFORT%_ *effort on* _%TIME%_*.*",
+            "blockOrphaned": "*Block orphaned at height* _%HEIGHT%_ *:(*",
+            "payment": "A payment of _%AMOUNT%_ has been sent."
+        }
+    },
+
+    "email": {
+        "enabled": false,
+        "fromAddress": "your@email.com",
+        "transport": "sendmail",
+        "sendmail": {
+            "path": "/usr/sbin/sendmail"
+        },
+        "smtp": {
+            "host": "smtp.example.com",
+            "port": 587,
+            "secure": false,
+            "auth": {
+                "user": "username",
+                "pass": "password"
+            },
+            "tls": {
+                "rejectUnauthorized": false
+            }
+        },
+        "mailgun": {
+            "key": "your-private-key",
+            "domain": "mg.yourdomain"
+        }
+    },
+
+    "telegram": {
+        "enabled": false,
+        "botName": "",
+        "token": "",
+        "channel": "",
+        "channelStats": {
+            "enabled": false,
+            "interval": 30
+        },
+        "botCommands": {
+            "stats": "/stats",
+            "report": "/report",
+            "notify": "/notify",
+            "blocks": "/blocks"
+        }
+    },
+    
+    "monitoring": {
+        "daemon": {
+            "checkInterval": 60,
+            "rpcMethod": "getblockcount"
+        },
+        "wallet": {
+            "checkInterval": 60,
+            "rpcMethod": "getbalance"
+        }
+    },
+
+    "prices": {
+        "source": "tradeogre",
+        "currency": "USD"
+    },
+    
+    "charts": {
+        "pool": {
+            "hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 1800,
+                "maximumPeriod": 86400
+            },
+            "workers": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 1800,
+                "maximumPeriod": 86400
+            },
+            "difficulty": {
+                "enabled": true,
+                "updateInterval": 1800,
+                "stepInterval": 10800,
+                "maximumPeriod": 604800
+            },
+            "price": {
+                "enabled": true,
+                "updateInterval": 1800,
+                "stepInterval": 10800,
+                "maximumPeriod": 604800
+            },
+            "profit": {
+                "enabled": true,
+                "updateInterval": 1800,
+                "stepInterval": 10800,
+                "maximumPeriod": 604800
+            }
+        },
+        "user": {
+            "hashrate": {
+                "enabled": true,
+                "updateInterval": 180,
+                "stepInterval": 1800,
+                "maximumPeriod": 86400
+            },
+            "worker_hashrate": {
+                "enabled": true,
+                "updateInterval": 60,
+                "stepInterval": 60,
+                "maximumPeriod": 86400
+            },
+            "payments": {
+                "enabled": true
+            }
+        },
+        "blocks": {
+            "enabled": true,
+            "days": 30
+        }
+    }
+}

--- a/lib/api.js
+++ b/lib/api.js
@@ -1674,9 +1674,9 @@ function getLogFiles(callback) {
 function minerSeenWithIPForAddress(address, ip, callback) {
     /**
     Mitigation for Docker Swarm Routing Mesh Ingress SNAT
-    Alter the html page to send "any" as the content of ip
+    If api.ignoreSrcIP, just return true no matter what IP we're given (because docker, or other load balancer, will rewrite the source IP)
     **/
-    if (ip === 'any') {
+    if (config.api.ignoreSrcIP) {
         callback(null, true)
     }
 

--- a/lib/api.js
+++ b/lib/api.js
@@ -109,7 +109,7 @@ function handleServerRequest(request, response) {
         case '/set_telegram_notifications':
             handleSetTelegramNotifications(urlParts, response);
             break;
-     
+
         // Miners hashrate (used for charts)
         case '/miners_hashrate':
             if (!authorize(request, response)) {
@@ -161,8 +161,8 @@ function handleServerRequest(request, response) {
                 return;
             }
 	    handleTestTelegramNotification(urlParts, response);
-            break;    
-        
+            break;
+
         // Default response
         default:
             response.writeHead(404, {
@@ -245,7 +245,7 @@ function collectStats(){
                     var hashParts = hashrates[i].split(':');
                     minersHashrate[hashParts[1]] = (minersHashrate[hashParts[1]] || 0) + parseInt(hashParts[0]);
                 }
-        
+
                 var totalShares = 0;
 
                 for (var miner in minersHashrate){
@@ -255,7 +255,7 @@ function collectStats(){
                         totalShares += minersHashrate[miner];
                         data.miners ++;
                     }
-            
+
                     minersHashrate[miner] = Math.round(minersHashrate[miner] / config.api.hashrateWindow);
 
                     if (!minerStats[miner]) { minerStats[miner] = {}; }
@@ -269,7 +269,7 @@ function collectStats(){
                 if (replies[5]){
                     for (var miner in replies[5]){
                         var roundScore = parseFloat(replies[5][miner]);
-            
+
                         data.roundScore += roundScore;
 
                         if (!minerStats[miner]) { minerStats[miner] = {}; }
@@ -498,7 +498,7 @@ function broadcastLiveStats(){
         if (!processAddresses[address]) processAddresses[address] = [];
         processAddresses[address].push(liveConnections[key]);
     }
-    
+
     for (var address in processAddresses) {
         var data = currentStats;
 
@@ -519,7 +519,7 @@ function broadcastLiveStats(){
         if (!processAddresses[address]) processAddresses[address] = [];
         processAddresses[address].push(addressConnections[key]);
     }
-    
+
     for (var address in processAddresses) {
         broadcastWorkerStats(address, processAddresses[address]);
     }
@@ -546,7 +546,7 @@ function broadcastWorkerStats(address, destinations) {
         stats.roundHashes = minerStats[address] && minerStats[address]['roundHashes'] ? minerStats[address]['roundHashes'] : 0;
 
         var paymentsData = replies[1];
-      
+
         var workersData = [];
         for (var j=0; j<replies[2].length; j++) {
             var key = replies[2][j];
@@ -628,7 +628,7 @@ function handleStats(urlParts, request, response){
 function handleMinerStats(urlParts, response){
     var address = urlParts.query.address;
     var longpoll = (urlParts.query.longpoll === 'true');
-    
+
     if (longpoll){
         response.writeHead(200, {
             'Access-Control-Allow-Origin': '*',
@@ -636,17 +636,17 @@ function handleMinerStats(urlParts, response){
             'Content-Type': 'application/json',
             'Connection': 'keep-alive'
         });
-        
+
         redisClient.exists(config.coin + ':workers:' + address, function(error, result){
             if (!result){
                 response.end(JSON.stringify({error: 'Not found'}));
                 return;
             }
-        
+
             var address = urlParts.query.address;
             var uid = Math.random().toString();
             var key = address + ':' + uid;
-        
+
             response.on("finish", function() {
                 delete addressConnections[key];
             });
@@ -674,7 +674,7 @@ function handleMinerStats(urlParts, response){
                 response.end(dataJSON);
                 return;
             }
-        
+
             var stats = replies[0];
             stats.hashrate = minerStats[address] && minerStats[address]['hashrate'] ? minerStats[address]['hashrate'] : 0;
             stats.roundScore = minerStats[address] && minerStats[address]['roundScore'] ? minerStats[address]['roundScore'] : 0;
@@ -708,7 +708,7 @@ function handleMinerStats(urlParts, response){
                         workersData[i].lastShare = replies[i]['lastShare'] ? parseInt(replies[i]['lastShare']) : 0;
                         workersData[i].hashes = replies[i]['hashes'] ? parseInt(replies[i]['hashes']) : 0;
                     }
-            
+
                     var data = {
                         stats: stats,
                         payments: paymentsData,
@@ -717,7 +717,7 @@ function handleMinerStats(urlParts, response){
                     }
 
                     var dataJSON = JSON.stringify(data);
-            
+
                     response.writeHead("200", {
                         'Access-Control-Allow-Origin': '*',
                         'Cache-Control': 'no-cache',
@@ -892,7 +892,7 @@ function compareTopMiners(a,b) {
 /**
  * Miner settings: minimum payout level
  **/
- 
+
 // Get current minimum payout level
 function handleGetMinerPayoutLevel(urlParts, response){
     response.writeHead(200, {
@@ -916,7 +916,7 @@ function handleGetMinerPayoutLevel(urlParts, response){
             response.end(JSON.stringify({status: 'Unable to get the current minimum payout level from database'}));
             return;
         }
-    
+
         var minLevel = config.payments.minPayment / config.coinUnits;
         if (minLevel < 0) minLevel = 0;
 
@@ -1058,7 +1058,7 @@ function handleSetMinerNotifications(urlParts, response){
         response.end(JSON.stringify({status: 'Invalid action'}));
         return;
     }
-    
+
     // Now only do a modification if we have seen the IP address in combination with the wallet address.
     minerSeenWithIPForAddress(address, ip, function (error, found) {
         if (!found || error) {
@@ -1178,7 +1178,7 @@ function handleSetTelegramNotifications(urlParts, response){
         response.end(JSON.stringify({status: 'No chat id specified'}));
         return;
     }
-    
+
     // Check action
     if (type !== 'default' && (action === undefined || action === '' || (action != 'enable' && action != 'disable'))) {
         response.end(JSON.stringify({status: 'Invalid action'}));
@@ -1215,7 +1215,7 @@ function handleSetTelegramNotifications(urlParts, response){
             });
             response.end(JSON.stringify({status: 'done'}));
         }
-    
+
         // Disable
         else if (action === "disable") {
             redisClient.hdel(config.coin + ':telegram:blocks', chatId, function(error, value){
@@ -1304,12 +1304,12 @@ function authorize(request, response){
     if(config.api.trustProxyIP && request.headers['x-forwarded-for']){
       remoteAddress = request.headers['x-forwarded-for'];
     }
-    
+
     var bindIp = config.api.bindIp ? config.api.bindIp : "0.0.0.0";
     if (typeof sentPass == "undefined" && (remoteAddress === '127.0.0.1' || remoteAddress === '::ffff:127.0.0.1' || remoteAddress === '::1' || (bindIp != "0.0.0.0" && remoteAddress === bindIp))) {
         return true;
     }
-    
+
     response.setHeader('Access-Control-Allow-Origin', '*');
 
     var cookies = parseCookies(request);
@@ -1672,10 +1672,19 @@ function getLogFiles(callback) {
  * Check if a miner has been seen with specified IP address
  **/
 function minerSeenWithIPForAddress(address, ip, callback) {
+    /**
+    Mitigation for Docker Swarm Routing Mesh Ingress SNAT
+    Alter the html page to send "any" as the content of ip
+    **/
+    if (ip === 'any') {
+        callback(error, true)
+    }
+
     var ipv4_regex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;
     if (ipv4_regex.test(ip)) {
         ip = '::ffff:' + ip;
     }
+
     redisClient.sismember([config.coin + ':workers_ip:' + address, ip], function(error, result) {
         var found = result > 0 ? true : false;
         callback(error, found);
@@ -1748,7 +1757,7 @@ if (config.api.ssl){
             ca: fs.readFileSync(config.api.sslCA),
             honorCipherOrder: true
         };
-    
+
         var ssl_server = https.createServer(options, function(request, response){
             if (request.method.toUpperCase() === "OPTIONS"){
                 response.writeHead("204", "No Content", {

--- a/lib/api.js
+++ b/lib/api.js
@@ -1677,7 +1677,7 @@ function minerSeenWithIPForAddress(address, ip, callback) {
     Alter the html page to send "any" as the content of ip
     **/
     if (ip === 'any') {
-        callback(error, true)
+        callback('IP test bypassed due to docker swarm routing mesh', true)
     }
 
     var ipv4_regex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;

--- a/lib/api.js
+++ b/lib/api.js
@@ -1677,7 +1677,7 @@ function minerSeenWithIPForAddress(address, ip, callback) {
     Alter the html page to send "any" as the content of ip
     **/
     if (ip === 'any') {
-        callback('IP test bypassed due to docker swarm routing mesh', true)
+        callback(null, true)
     }
 
     var ipv4_regex = /\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3}/;

--- a/lib/apiInterfaces.js
+++ b/lib/apiInterfaces.js
@@ -65,7 +65,7 @@ function rpc(host, port, method, params, callback, password){
         params: params
     });
     if (password !== undefined) {
-        request['password'] = password;
+        data['password'] = password;
     }
     jsonHttpRequest(host, port, data, function(error, replyJson){
         if (error){

--- a/lib/apiInterfaces.js
+++ b/lib/apiInterfaces.js
@@ -57,13 +57,16 @@ function jsonHttpRequest(host, port, data, callback, path){
 /**
  * Send RPC request
  **/
-function rpc(host, port, method, params, callback){
+function rpc(host, port, method, params, callback, password){
     var data = JSON.stringify({
         id: "0",
         jsonrpc: "2.0",
         method: method,
         params: params
     });
+    if (password !== undefined) {
+        request['password'] = password;
+    }
     jsonHttpRequest(host, port, data, function(error, replyJson){
         if (error){
             callback(error, {});

--- a/lib/apiInterfaces.js
+++ b/lib/apiInterfaces.js
@@ -59,14 +59,16 @@ function jsonHttpRequest(host, port, data, callback, path){
  **/
 function rpc(host, port, method, params, callback, password){
     var data = JSON.stringify({
+    var request = {
         id: "0",
         jsonrpc: "2.0",
         method: method,
         params: params
-    });
+    };
     if (password !== undefined) {
-        data['password'] = password;
+        request['password'] = password;
     }
+    var data = JSON.stringify(request);
     jsonHttpRequest(host, port, data, function(error, replyJson){
         if (error){
             callback(error, {});

--- a/lib/apiInterfaces.js
+++ b/lib/apiInterfaces.js
@@ -58,7 +58,6 @@ function jsonHttpRequest(host, port, data, callback, path){
  * Send RPC request
  **/
 function rpc(host, port, method, params, callback, password){
-    var data = JSON.stringify({
     var request = {
         id: "0",
         jsonrpc: "2.0",

--- a/lib/apiInterfaces.js
+++ b/lib/apiInterfaces.js
@@ -109,7 +109,8 @@ module.exports = function(daemonConfig, walletConfig, poolApiConfig){
             rpc(daemonConfig.host, daemonConfig.port, method, params, callback);
         },
         rpcWallet: function(method, params, callback){
-            rpc(walletConfig.host, walletConfig.port, method, params, callback);
+            rpc(walletConfig.host, walletConfig.port, method, params, callback,
+	walletConfig.password);
         },
         pool: function(path, callback){
             var bindIp = config.api.bindIp ? config.api.bindIp : "0.0.0.0";

--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -211,7 +211,7 @@ function runInterval(){
                 var rpcCommand = "transfer";
                 var rpcRequest = transferCmd.rpc;
 
-                if (daemonType === "bytecoin") {
+                if (daemonType === "bytecoin" || daemonType === "kepl") {
                     rpcCommand = "sendTransaction";
                     rpcRequest = {
                         transfers: transferCmd.rpc.destinations,

--- a/website_example/pages/settings.html
+++ b/website_example/pages/settings.html
@@ -217,7 +217,7 @@ function setEmailNotifications(email, address, ip, enable) {
         url: api + '/set_email_notifications',
         data: {
             address: address,
-            ip: ip,
+            ip: 'any',
             email: email,
             action: enable ? 'enable' : 'disable'
         },
@@ -241,7 +241,7 @@ $('#enableButton').click(function(){
     var address = $('#yourAddress').val().trim();
     var ip = $('#yourIP').val().trim();
     var email = $('#yourEmail').val();
-    setEmailNotifications(email, address, ip, true);
+    setEmailNotifications(email, address, 'any', true);
 });
 
 // Handle click on Disable button
@@ -249,6 +249,6 @@ $('#disableButton').click(function(){
     var address = $('#yourAddress').val().trim();
     var ip = $('#yourIP').val().trim();
     var email = $('#yourEmail').val();
-    setEmailNotifications(email, address, ip, false);
+    setEmailNotifications(email, address, 'any', false);
 });
 </script>


### PR DESCRIPTION
When running with in Docker Swarm, or behind a load balancer which does NAT, the miner's true IP is never revealed to the pool, only the IP of the load balancer. This PR adds a config option which will force the API to accept **any** IP as belonging to the miner, allowing them to set custom payout threshold, and enable email notifications.