### PR TITLE
Add ability to use first vout for block reward

### DIFF
--- a/README.md
+++ b/README.md
@@ -359,7 +359,8 @@ Explanation for each field:
     "depth": 60,
     "poolFee": 0.8, // 0.8% pool fee (1% total fee total including donations)
     "devDonation": 0.2, // 0.2% donation to send to pool dev
-    "networkFee": 0.0, // Network/Governance fee (used by some coins like Loki)
+    "networkFee": 0.0, // Network/Governance fee (used by some coins)
+    "useFirstVout": false, // Should be true for a coin like Loki that has multiple block reward recipients where first is miner reward
     
     /* Some forknote coins have an issue with block height in RPC request, to fix you can enable this option.
        See: https://github.com/forknote/forknote-pool/issues/48 */

--- a/config_examples/loki.json
+++ b/config_examples/loki.json
@@ -125,7 +125,8 @@
         "depth": 60,
         "poolFee": 0.8,
         "devDonation": 0.2,
-        "networkFee": 5.0
+        "networkFee": 0.0,
+        "useFirstVout": true
     },
 
     "api": {

--- a/lib/api.js
+++ b/lib/api.js
@@ -480,7 +480,31 @@ function getLastBlockData(callback) {
            return;
        }
        var blockHeader = reply.block_header;
-       callback(null, {
+        if (config.blockUnlocker.useFirstVout) {
+            apiInterfaces.rpcDaemon('getblock', { height: blockHeader.height }, function(error, result) {
+                if (error) {
+                    log('error', logSystem, 'Error getting last block details: %j', [error]);
+                    callback(true);
+                    return;
+                }
+                var vout = JSON.parse(result.json).miner_tx.vout;
+                if (!vout.length) {
+                    log('error', logSystem, 'Error: tx at height %s has no vouts!', [blockHeader.height]);
+                    callback(true);
+                    return;
+                }
+                callback(null, {
+                    difficulty: blockHeader.difficulty,
+                    height: blockHeader.height,
+                    timestamp: blockHeader.timestamp,
+                    reward: vout[0].amount,
+                    hash:  blockHeader.hash
+                });
+            });
+            return;
+        }
+
+        callback(null, {
             difficulty: blockHeader.difficulty,
             height: blockHeader.height,
             timestamp: blockHeader.timestamp,

--- a/lib/blockUnlocker.js
+++ b/lib/blockUnlocker.js
@@ -65,15 +65,16 @@ function runInterval(){
             async.filter(blocks, function(block, mapCback){
                 var daemonType = config.daemonType ? config.daemonType.toLowerCase() : "default";
                 var blockHeight = (daemonType === "forknote" || daemonType === "bytecoin" || config.blockUnlocker.fixBlockHeightRPC) ? block.height + 1 : block.height;
-                apiInterfaces.rpcDaemon('getblockheaderbyheight', {height: blockHeight}, function(error, result){
+                var rpcmethod = config.blockUnlocker.useFirstVout ? 'getblock' : 'getblockheaderbyheight';
+                apiInterfaces.rpcDaemon(rpcmethod, {height: blockHeight}, function(error, result){
                     if (error){
-                        log('error', logSystem, 'Error with getblockheaderbyheight RPC request for block %s - %j', [block.serialized, error]);
+                        log('error', logSystem, 'Error with %s RPC request for block %s - %j', [rpcmethod, block.serialized, error]);
                         block.unlocked = false;
                         mapCback();
                         return;
                     }
                     if (!result.block_header){
-                        log('error', logSystem, 'Error with getblockheaderbyheight, no details returned for %s - %j', [block.serialized, result]);
+                        log('error', logSystem, 'Error with %s, no details returned for %s - %j', [rpcmethod, block.serialized, result]);
                         block.unlocked = false;
                         mapCback();
                         return;
@@ -81,7 +82,18 @@ function runInterval(){
                     var blockHeader = result.block_header;
                     block.orphaned = blockHeader.hash === block.hash ? 0 : 1;
                     block.unlocked = blockHeader.depth >= config.blockUnlocker.depth;
-                    block.reward = blockHeader.reward;
+                    if (config.blockUnlocker.useFirstVout) {
+                        var vout = JSON.parse(result.json).miner_tx.vout;
+                        if (!vout.length) {
+                            log('error', logSystem, 'Error: tx at height %s has no vouts!', [blockHeight]);
+                            block.unlocked = false;
+                            mapCback();
+                            return;
+                        }
+                        block.reward = vout[0].amount;
+                    } else {
+                        block.reward = blockHeader.reward;
+                    }
                     if (config.blockUnlocker.networkFee) {
                         var networkFeePercent = config.blockUnlocker.networkFee / 100;
                         block.reward = block.reward - (block.reward * networkFeePercent);


### PR DESCRIPTION
Loki, in particular, no longer uses a constant fee: most blocks don't include the governance reward, but then there is an occassional very large reward with includes a large governance reward.  The proper solution here is to use the first vout to extract the miner reward, which this patch adds support for.

I don't actually have a Loki pool to test this on; it is based on a patch for a heavily-modified pool.  I'd appreciate if someone could give it a try and confirm that it works on an actual loki pool before it gets merged.