### PR TITLE
Correct handling of CryptoNight v8 ReverseWaltz

### DIFF
--- a/config_examples/graft.json
+++ b/config_examples/graft.json
@@ -9,7 +9,7 @@
 
     "daemonType": "default",
     "cnAlgorithm": "cryptonight",
-    "cnVariant": 1,
+    "cnVariant": 14,
     "cnBlobType": 0,
 
     "logging": {

--- a/website_example/pages/getting_started.html
+++ b/website_example/pages/getting_started.html
@@ -404,6 +404,9 @@ currentPage = {
 	    } else if (cnVariant === 12) {
                 algorithm = 'Cryptonight (Wow)';
                 xmrstakAlgo = 'cn/wow';
+            } else if (cnVariant === 14) {
+                algorithm = 'Cryptonight v8 ReverseWaltz';
+                xmrstakAlgo = 'cryptonight_v8_reversewaltz';
             } else {
                 algorithm = 'Cryptonight (Original)';
                 xmrstakAlgo = 'cryptonight';


### PR DESCRIPTION
Added correct handling of CryptoNight v8 ReverseWaltz. 
[MoneroOcean/node-cryptonight-hashing](https://github.com/MoneroOcean/node-cryptonight-hashing) already has CryptoNight v8 ReverseWaltz support.

Please, let me know, if you need something else for correct support of CryptoNight v8 ReverseWaltz.