### PR TITLE
About the height broadcast in pool.js

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -364,6 +364,7 @@ Miner.prototype = {
                 blob: blob,
                 job_id: newJob.id,
                 target: target,
+                height: currentBlockTemplate.height,
                 id: this.id
             };
         }else {


### PR DESCRIPTION
The cachedJob do not include the info of height which is needed by the algo like cn/r, cn/wow, etc... And while the miner connect the pool, if the pool use cachejob to broadcast the first Job, it will make the miner get job with no height info and result wrong share.