### PR TITLE
Improvement for getblocktemplate,  stop sending duplicate job and minimum fixed difficulty per port

### DIFF
--- a/README.md
+++ b/README.md
@@ -253,6 +253,7 @@ Explanation for each field:
         {
             "port": 3333, // Port for mining apps to connect to
             "difficulty": 2000, // Initial difficulty miners are set to
+            "MinFixDiff": 75000, // Minimal miner fixed difficulty (not mandatory)
             "desc": "Low end hardware" // Description of port
         },
         {

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -488,6 +488,10 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                         difficulty = portData.difficulty;
                     } else {
                         noRetarget = true;
+                        if (portData.MinFixDiff) {
+							if (difficulty < portData.MinFixDiff)
+								difficulty = portData.MinFixDiff;
+						}
                         if (difficulty < config.poolServer.varDiff.minDiff) {
                             difficulty = config.poolServer.varDiff.minDiff;
                         }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -250,7 +250,7 @@ function jobRefresh(loop){
 
             for (var minerId in connectedMiners){
                 var miner = connectedMiners[minerId];
-                miner.pushMessage('job', miner.getJob());
+                miner.sendNewJob();
             }
             callback(true);
         }],
@@ -297,7 +297,7 @@ function Miner(id, login, pass, ip, port, agent, workerName, startingDiff, noRet
     this.noRetarget = noRetarget;
     this.difficulty = startingDiff;
     this.validJobs = [];
-
+    this.sentJobs = [];
     // Vardiff related variables
     this.shareTimeRing = utils.ringBuffer(16);
     this.lastShareTime = Date.now() / 1000 | 0;
@@ -351,7 +351,7 @@ Miner.prototype = {
         if (this.difficulty === newDiff) return;
         log('info', logSystem, 'Retargetting difficulty %d to %d for %s', [this.difficulty, newDiff, this.login]);
         this.pendingDifficulty = newDiff;
-        this.pushMessage('job', this.getJob());
+        this.sendNewJob();
     },
     heartbeat: function(){
         this.lastBeat = Date.now();
@@ -445,6 +445,22 @@ Miner.prototype = {
         if (typeof config.includeHeight !== "undefined" && config.includeHeight)
             this.cachedJob['height'] = currentBlockTemplate.height
         return this.cachedJob;
+    },
+    sendNewJob: function() {
+            let job = this.getJob();
+            let tempJob = this.sentJobs.filter(function (intJob) {
+                return intJob.id === job.job_id;
+            })[0];
+
+            if (tempJob) {
+                log('warn', logSystem, 'Duplicate Job Blocked');
+                return;
+            }
+            
+            this.sentJobs.push(job);
+            if (this.sentJobs.length > 8) this.sentJobs.shift();
+            
+            return this.pushMessage('job', job);
     },
     checkBan: function(validShare){
         if (!banningEnabled) return;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -489,9 +489,8 @@ function handleMinerMethod(method, params, ip, portData, sendReply, pushMessage)
                     } else {
                         noRetarget = true;
                         if (portData.MinFixDiff) {
-							if (difficulty < portData.MinFixDiff)
-								difficulty = portData.MinFixDiff;
-						}
+			  if (difficulty < portData.MinFixDiff) difficulty = portData.MinFixDiff;
+			}
                         if (difficulty < config.poolServer.varDiff.minDiff) {
                             difficulty = config.poolServer.varDiff.minDiff;
                         }

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -143,6 +143,8 @@ function BlockTemplate(template){
     this.reserveOffset = template.reserved_offset;
     this.buffer = Buffer.from(this.blob, 'hex');
     instanceId.copy(this.buffer, this.reserveOffset + 4, 0, 3);
+    this.previous_hash = Buffer.alloc(32);
+    this.buffer.copy(this.previous_hash, 0, 7, 39);
     this.extraNonce = 0;
 
     // The clientNonceLocation is the location at which the client pools should set the nonces for each of their clients.
@@ -174,50 +176,92 @@ function getBlockTemplate(callback){
 }
 
 /**
- * Process block template
+ * Get LastBlock Header
  **/
-function processBlockTemplate(template){
-    if (currentBlockTemplate)
-        validBlockTemplates.push(currentBlockTemplate);
-
-    if (validBlockTemplates.length > 3)
-        validBlockTemplates.shift();
-
-    currentBlockTemplate = new BlockTemplate(template);
-
-    for (var minerId in connectedMiners){
-        var miner = connectedMiners[minerId];
-        miner.pushMessage('job', miner.getJob());
-    }
+function getLastBlockHeader(callback){   
+    apiInterfaces.rpcDaemon('getlastblockheader',{}, callback);
 }
 
 /**
  * Job refresh
  **/
-function jobRefresh(loop, callback){
-    callback = callback || function(){};
-    getBlockTemplate(function(error, result){
-         if (loop)
-            setTimeout(function(){
-                jobRefresh(true);
-            }, config.poolServer.blockRefreshInterval);
-        
-        if (error){
-            log('error', logSystem, 'Error polling getblocktemplate %j', [error]);
-            if (!poolStarted) log('error', logSystem, 'Could not start pool');
-            callback(false);
-            return;
-        }
+ 
+function jobRefresh(loop){
+    async.waterfall([
+        function(callback){
+            if (!poolStarted) {
+                startPoolServerTcp(function(successful){ poolStarted = true });
+                setTimeout(jobRefresh, 2500, loop);
+                return;
+            }
 
-        if (!currentBlockTemplate || result.height > currentBlockTemplate.height) {
-            log('info', logSystem, 'New block to mine at height %d w/ difficulty of %d', [result.height, result.difficulty]);
-            processBlockTemplate(result);
+            getLastBlockHeader(function(err, res){
+                if(err){
+                    setTimeout(jobRefresh, 1000, loop);
+                    return;
+                }                   
+                if (res.status === "OK" && res.hasOwnProperty('block_header')){
+                    let LastHash = res.block_header.hash.toString('hex');
+                    if (!currentBlockTemplate || LastHash !== currentBlockTemplate.previous_hash.toString('hex')) {
+                        callback(null, true);
+                        return;
+                    }else{    
+                       callback(true);
+                       return;                           
+                    }
+                } else {
+                    setTimeout(jobRefresh, 3000, loop);
+                    return;
+                }
+            });
+              
+        },
+        function(getbc, callback){
+            let start = new Date();	
+            getBlockTemplate(function(err, result){	
+                if (err){
+                    log('error', logSystem, 'Error polling getblocktemplate %j', [err]);
+                    if (!poolStarted) log('error', logSystem, 'Could not start pool');
+                    setTimeout(jobRefresh, 1000, loop);
+                    return;
+                }
+              
+                let buffer = Buffer.from(result.blocktemplate_blob, 'hex');
+                let new_hash = Buffer.alloc(32);
+                buffer.copy(new_hash, 0, 7, 39);
+                if (!currentBlockTemplate || new_hash.toString('hex') !== currentBlockTemplate.previous_hash.toString('hex')) {
+                    log('info', logSystem, 'New Block To Mine at height %d w/ difficulty of %d', [result.height, result.difficulty]);
+                        callback(null, result);
+                    return;
+                }else{
+                    callback("Duplicate Template Blocked");
+                    return;
+                }
+            })
+        },
+        function(template, callback){
+            if (currentBlockTemplate)
+                validBlockTemplates.push(currentBlockTemplate);
+
+            if (validBlockTemplates.length > 3)
+                validBlockTemplates.shift();
+
+            currentBlockTemplate = new BlockTemplate(template);
+
+            for (var minerId in connectedMiners){
+                var miner = connectedMiners[minerId];
+                miner.pushMessage('job', miner.getJob());
+            }
+            callback(true);
+        }],
+        function(err){
+            if (loop === true){
+                setTimeout(function(){
+                    jobRefresh(true);
+                },config.poolServer.blockRefreshInterval);
+            }
         }
-        if (!poolStarted) {
-            startPoolServerTcp(function(successful){ poolStarted = true });
-        }
-        callback(true);
-    })
+    );	
 }
 
 /**

--- a/website_example/pages/getting_started.html
+++ b/website_example/pages/getting_started.html
@@ -36,6 +36,7 @@
                     <tr>
                         <th class="col1"><span tkey="port">Port</span></th>
                         <th class="col2"><span tkey="portDiff">Starting Difficulty</span></th>
+			<th class="col2"><span tkey="MinFixDiff">Minimum Fixed Difficulty</span></th>
                         <th class="col3"><span tkey="description">Description</span></th>
                     </tr>
                     </thead>
@@ -43,6 +44,7 @@
                     <tr>
                         <td class="col1"><span class="miningPort"></span></td>
                         <td class="col2"><span class="miningPortDiff"></span></td>
+			<td class="col2"><span class="miningPortMinDiff"></span></td>
                         <td class="col3"><span class="miningPortDesc"></span></td>
                     </tr>
                     </tbody>
@@ -343,6 +345,11 @@ currentPage = {
                 $portChild.find('.miningPort').text(portData.port);
                 $portChild.find('.miningPortDiff').text(formatDifficulty(portData.difficulty));
                 $portChild.find('.miningPortDesc').text(portData.desc);
+		if(portData.MinFixDiff){
+		  $portChild.find('.miningPortMinDiff').text(formatDifficulty(portData.MinFixDiff));
+                }else{
+		  $portChild.find('.miningPortMinDiff').text("~");
+		}
                 $miningPortChildren.push($portChild);
 		$miningPortOptions.push('<option value="'+portData.port+'">'+portData.port+' &ndash; '+portData.desc+'</option>');
             }


### PR DESCRIPTION
The new  function for pooling daemon  drastically lower CPU Utilization when pool use lot of threads.
 I use it on my pool for months without any issues but needs to be tested in heavy load on a large pool.
you can lower "blockRefreshInterval" to 250~300