### PR TITLE
Support 'ring_size' transfer RPC parameter for payments

### DIFF
--- a/lib/paymentProcessor.js
+++ b/lib/paymentProcessor.js
@@ -128,6 +128,7 @@ function runInterval(){
             let addresses = 0;
             let commandAmount = 0;
             let commandIndex = 0;
+            let ringSize = config.payments.ringSize ? config.payments.ringSize : config.payments.mixin;
             
             for (let worker in payments){
                 let amount = parseInt(payments[worker]);
@@ -171,11 +172,14 @@ function runInterval(){
                         rpc: {
                             destinations: [],
                             fee: config.payments.transferFee,
-                            mixin: config.payments.mixin,
                             priority: config.payments.priority,
                             unlock_time: 0
                         }
                     };
+                    if (config.payments.ringSize)
+                        transferCommands[commandIndex].rpc.ring_size = ringSize;
+                    else
+                        transferCommands[commandIndex].rpc.mixin = ringSize;
                 }
 
                 transferCommands[commandIndex].rpc.destinations.push({amount: amount, address: address});
@@ -216,7 +220,7 @@ function runInterval(){
                     rpcRequest = {
                         transfers: transferCmd.rpc.destinations,
                         fee: transferCmd.rpc.fee,
-                        anonymity: transferCmd.rpc.mixin,
+                        anonymity: ringSize,
                         unlockTime: transferCmd.rpc.unlock_time
                     };
                     if (transferCmd.rpc.payment_id) {
@@ -240,7 +244,7 @@ function runInterval(){
                         txHash,
                         transferCmd.amount,
                         transferCmd.rpc.fee,
-                        transferCmd.rpc.mixin,
+                        ringSize,
                         Object.keys(transferCmd.rpc.destinations).length
                     ].join(':')]);
 
@@ -254,7 +258,7 @@ function runInterval(){
                             txHash,
                             destination.amount,
                             transferCmd.rpc.fee,
-                            transferCmd.rpc.mixin
+                            ringSize
                         ].join(':')]);
 
                         notify_miners_on_success.push(destination);


### PR DESCRIPTION
- 'mixin' parameter was removed from RPC API, see:
https://github.com/monero-project/monero/commit/023f2c77472e56751b46820a3bbb20dde82b0185#diff-27aa76d79152f1d9630da4e9f06b9067
- For backwards compatibility new RPC parameter is only used if user
  includes 'ringSize' parameter in payments section of config.json