### PR TITLE
Prevent API crashes if childPools not defined in config.json

### DIFF
--- a/init.js
+++ b/init.js
@@ -23,7 +23,9 @@ var redisDB = (config.redis.db && config.redis.db > 0) ? config.redis.db : 0;
 global.redisClient = redis.createClient(config.redis.port, config.redis.host, { db: redisDB, auth_pass: config.redis.auth });
 
 if (typeof config.childPools !== 'undefined')
-    config.childPools = config.childPools.filter(pool => pool.enabled)
+    config.childPools = config.childPools.filter(pool => pool.enabled);
+else
+    config.childPools = [];
 
 // Load pool modules
 if (cluster.isWorker){


### PR DESCRIPTION
- Several places in api.js assume childPools is defined, set if to an
  empty array by default so front-end still works