### PR TITLE
Talleo algorithm negotiation for xmrig

### DIFF
--- a/config_examples/talleo.json
+++ b/config_examples/talleo.json
@@ -15,7 +15,7 @@
     "cnVariant": 2,
     "cnBlobType": 2,
     "includeHeight": false,
-    "includeAlgo": false,
+    "includeAlgo": "cn/ultra",
 
     "hashingUtil": true,
 


### PR DESCRIPTION
xmrig recently added support for Talleo's algorithm in development branch. This fix makes sure xmrig uses correct algorithm even if user specifies wrong algorithm. Older xmrig versions will print error message to make it clear user is trying unsupported combination.