### PR TITLE
fix trtl daemon get_info

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -567,7 +567,7 @@ function getNetworkData (callback, rpcMode) {
 	// Try get_info RPC method first if available (not all coins support it)
 	if (rpcMode === 'get_info') {
 		apiInterfaces.rpcDaemon('get_info', {}, function (error, reply) {
-			if (error) {
+			if (error || !reply) {
 				getNetworkData(callback, 'getlastblockheader');
 				return;
 			} else {


### PR DESCRIPTION
trtl v.0.22.0: The /getinfo, /getheight, /getpeers, and /getfee calls have been removed in lieu of /info, /height, /peers, and /fee.
This quick fix fallback to getlastblockheader if get_info fail because of empty reply.