### PR TITLE
added haven-offshore support to pool code

### DIFF
--- a/lib/pool.js
+++ b/lib/pool.js
@@ -42,6 +42,9 @@ let cnAlgorithm = config.cnAlgorithm || "cryptonight";
 let cnVariant = config.cnVariant || 0;
 let cnBlobType = config.cnBlobType || 0;
 
+// HBD - check for HAVEN coin type
+let bUseHaven = (config.coin == "haven");
+
 let cryptoNight;
 if (!cnHashing || !cnHashing[cnAlgorithm]) {
 	log('error', logSystem, 'Invalid cryptonight algorithm: %s', [cnAlgorithm]);
@@ -58,7 +61,8 @@ let connectedMiners = {};
 // Get merged mining tag reseved space size
 let POOL_NONCE_SIZE = 16 + 1; // +1 for old XMR/new TRTL bugs
 let EXTRA_NONCE_TEMPLATE = "02" + POOL_NONCE_SIZE.toString(16) + "00".repeat(POOL_NONCE_SIZE);
-let POOL_NONCE_MM_SIZE = POOL_NONCE_SIZE + utils.cnUtil.get_merged_mining_nonce_size();
+let POOL_NONCE_MM_SIZE = POOL_NONCE_SIZE +
+    bUseHaven ? utils.havenUtil.get_merged_mining_nonce_size() : utils.cnUtil.get_merged_mining_nonce_size();
 let EXTRA_NONCE_NO_CHILD_TEMPLATE = "02" + POOL_NONCE_MM_SIZE.toString(16) + "00".repeat(POOL_NONCE_MM_SIZE);
 let mergedMining = config.poolServer.mergedMining && (Array.isArray(config.childPools) && config.childPools.length > 0)
 
@@ -183,7 +187,7 @@ process.on('message', function (message) {
 			break;
 		case 'BlockTemplate':
 			let buffer = Buffer.from(message.block.blocktemplate_blob, 'hex');
-			let new_hash = Buffer.alloc(32);
+	                let new_hash = Buffer.alloc(32);
 			buffer.copy(new_hash, 0, previousOffset, 39);
 			try {
 				if (!currentBlockTemplate[0] || new_hash.toString('hex') !== currentBlockTemplate[0].prev_hash.toString('hex') || (currentBlockTemplate[0].num_transactions == 0 && message.block.num_transactions > 0)) {
@@ -237,7 +241,7 @@ function BlockTemplate (template, parent, indexOfChildPool) {
 	let blob = this.blocktemplate_blob;
 	this.buffer = Buffer.from(blob, 'hex');
 	let template_hex = EXTRA_NONCE_TEMPLATE;
-	if (parent && mergedMining) {
+	if (parent && mergedMining && !bUseHaven) {
 		if (currentChildBlockTemplate[indexOfChildPool]) {
 			this.childBlockTemplate = currentChildBlockTemplate[indexOfChildPool];
 			this.buffer = utils.cnUtil.construct_mm_parent_block_blob(this.buffer, cnBlobType, this.childBlockTemplate.buffer);
@@ -275,11 +279,15 @@ function BlockTemplate (template, parent, indexOfChildPool) {
 }
 BlockTemplate.prototype = {
 	nextBlob: function (index) {
-		this.buffer.writeUInt32BE(++this.extraNonce, this.reserveOffset);
-		if (mergedMining && this.childBlockTemplate) {
-			return utils.cnUtil.convert_blob(this.buffer, cnBlobType, this.childBlockTemplate.buffer)
-				.toString('hex')
-		}
+	    this.buffer.writeUInt32BE(++this.extraNonce, this.reserveOffset);
+	    if (!bUseHaven && mergedMining && this.childBlockTemplate) {
+		return utils.cnUtil.convert_blob(this.buffer, cnBlobType, this.childBlockTemplate.buffer)
+		    .toString('hex')
+	    }
+	    if (bUseHaven)
+		return utils.havenUtil.convert_blob(this.buffer)
+			.toString('hex');
+	    else
 		return utils.cnUtil.convert_blob(this.buffer, cnBlobType)
 			.toString('hex');
 	},
@@ -1158,7 +1166,9 @@ function getShareBuffer (miner, job, blockTemplate, params) {
 	}
 
 	try {
-		let shareBuffer = utils.cnUtil.construct_block_blob(template, Buffer.from(nonce, 'hex'), cnBlobType);
+	    let shareBuffer = (bUseHaven)
+		? utils.havenUtil.construct_block_blob(template, Buffer.from(nonce, 'hex'))
+		: utils.cnUtil.construct_block_blob(template, Buffer.from(nonce, 'hex'), cnBlobType);
 		return shareBuffer;
 	} catch (e) {
 		log('error', logSystem, "Can't get share buffer with nonce %s from %s@%s: %s", [nonce, miner.login, miner.ip, e]);
@@ -1182,7 +1192,9 @@ function processShare (miner, job, blockTemplate, params) {
 		hash = Buffer.from(resultHash, 'hex');
 		shareType = 'trusted';
 	} else {
-		let convertedBlob = utils.cnUtil.convert_blob(shareBuffer, cnBlobType);
+	    let convertedBlob = (bUseHaven)
+		? utils.havenUtil.convert_blob(shareBuffer)
+		: utils.cnUtil.convert_blob(shareBuffer, cnBlobType);
 		let hard_fork_version = convertedBlob[0];
 
 		if (blockTemplate.isRandomX) {
@@ -1213,8 +1225,9 @@ function processShare (miner, job, blockTemplate, params) {
 			if (error) {
 				log('error', logSystem, 'Error submitting block at height %d from %s@%s, share type: "%s" - %j', [job.height, miner.login, miner.ip, shareType, error]);
 			} else {
-				let blockFastHash = utils.cnUtil.get_block_id(shareBuffer, cnBlobType)
-					.toString('hex');
+			    let blockFastHash = (bUseHaven)
+				? utils.havenUtil.get_block_id(shareBuffer).toString('hex')
+				: utils.cnUtil.get_block_id(shareBuffer, cnBlobType).toString('hex');
 				log('info', logSystem,
 					'Block %s found at height %d by miner %s@%s - submit result: %j',
 					[blockFastHash.substr(0, 6), job.height, miner.login, miner.ip, result]
@@ -1235,7 +1248,7 @@ function processShare (miner, job, blockTemplate, params) {
 	var childBlockTemplate = blockTemplate.childBlockTemplate;
 
 	if (childBlockTemplate) {
-		if (mergedMining) {
+		if (!bUseHaven && mergedMining) {
 			let pool = config.childPools[miner.activeChildPool]
 			if (hashDiff.ge(childBlockTemplate.difficulty)) {
 				let mergedBuffer = null

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -14,6 +14,9 @@ exports.dateFormat = dateFormat;
 let cnUtil = require('cryptoforknote-util');
 exports.cnUtil = cnUtil;
 
+let havenUtil = require('haven-nodejs-wrapper');
+exports.havenUtil = havenUtil;
+
 /**
  * Generate random instance id
  **/

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
 		"cryptoforknote-util": "git://github.com/MoneroOcean/node-cryptoforknote-util.git",
 		"cryptonight-hashing": "git://github.com/MoneroOcean/node-cryptonight-hashing.git",
 		"dateformat": "*",
+		"haven-nodejs-wrapper": "git://github.com/haven-protocol-org/haven-nodejs-wrapper",
 		"mailgun.js": "*",
 		"node-telegram-bot-api": "*",
 		"nodemailer": "2.7.2",


### PR DESCRIPTION
Haven Apollo now provides offshore functionality, which requires a change to the block_header format (among other changes). In order for the pool code to support this, a new module has been created to sit alongside **MoneroOcean's cryptoforknote-util**. 

This pull request adds the new **haven-nodejs-wrapper** module as a dependency to the pool code. 