### PR TITLE
[Talleo] Discard block templates with 0 transactions starting from height 10000.

### DIFF
--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -73,6 +73,10 @@ function runInterval () {
 						callback(null)
 						return
 					}
+					if (config.coin == 'talleo' && res.result.height >= 10000 && res.result.num_transactions == 0) {
+						callback(null)
+						return
+					}
 					process.send({
 						type: 'BlockTemplate',
 						block: res.result


### PR DESCRIPTION
This allows miners to continue mining previous block height until the new block has at least 1 transaction. Otherwise the new block template would get rejected if a miner manages to solve it before it is refreshed with more transactions.

It is currently not possible to merge-mine Talleo so this enhancement is only required for parent daemon.