### PR TITLE
[Talleo] Revert adding 'alwaysPoll'

### DIFF
--- a/config_examples/talleo.json
+++ b/config_examples/talleo.json
@@ -160,8 +160,7 @@
 
 	"daemon": {
 		"host": "127.0.0.1",
-		"port": 33888,
-		"alwaysPoll": true
+		"port": 33888
 	},
 
 	"wallet": {

--- a/lib/childDaemon.js
+++ b/lib/childDaemon.js
@@ -43,9 +43,6 @@ function runInterval () {
 							log('info', logSystem, '%s found new hash %s', [pool.coin, hash]);
 							callback(null, true);
 							return;
-						} else if (config.daemon.alwaysPoll || false) {
-							callback(null, true);
-							return;
 						} else {
 							callback(true);
 							return;

--- a/lib/daemon.js
+++ b/lib/daemon.js
@@ -47,9 +47,6 @@ function runInterval () {
 							log('info', logSystem, '%s found new hash %s', [config.coin, hash]);
 							callback(null, true);
 							return;
-						} else if (config.daemon.alwaysPoll || false) {
-							callback(null, true);
-							return;
 						} else {
 							callback(true);
 							return;

--- a/lib/pool.js
+++ b/lib/pool.js
@@ -489,15 +489,14 @@ Miner.prototype = {
 			if (this.lastBlockHeight === blockTemplate.height &&
 				(!currentChildBlockTemplate[this.activeChildPool] || this.lastChildBlockHeight === currentChildBlockTemplate[this.activeChildPool].height) &&
 				!this.pendingDifficulty &&
-				this.cachedJob !== null &&
-				!config.daemon.alwaysPoll) {
+				this.cachedJob !== null) {
 				return this.cachedJob;
 			}
 			this.lastChildBlockHeight = currentChildBlockTemplate ? currentChildBlockTemplate[this.activeChildPool].height : -1;
 			newJob.activeChildPool = this.activeChildPool
 			newJob.childHeight = this.lastChildBlockHeight
 		} else {
-			if (this.lastBlockHeight === blockTemplate.height && !this.pendingDifficulty && this.cachedJob !== null && !config.daemon.alwaysPoll) {
+			if (this.lastBlockHeight === blockTemplate.height && !this.pendingDifficulty && this.cachedJob !== null) {
 				return this.cachedJob;
 			}
 		}


### PR DESCRIPTION
* On pools with low hashing power using 'alwaysPoll' will cause almost no blocks to be found as time between block templates will be too short.
* Because we now discard blocks with no transactions, we can compare just block height