### PR TITLE
Fix the blockUnlocker.js from crashing

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
 		"url": "https://github.com/dvandal/cryptonote-nodejs-pool.git"
 	},
 	"dependencies": {
-		"async": "^3.2.0",
+		"async": "^1.5.2",
 		"base58-native": "*",
 		"bignum": "*",
 		"bufferutil": "*",


### PR DESCRIPTION
When using `async@3.2.0` it gives you the following error:
```JS
TypeError: blocks.map is not a function                                                                                                                                     
    at /root/cryptonote-nodejs-pool/lib/blockUnlocker.js:120:31                                                                                                               
    at nextTask (/root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:5791:27) 
    at next (/root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:5799:13)                                                                                           
    at /root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:329:20             
    at /root/cryptonote-nodejs-pool/lib/blockUnlocker.js:113:5                          
    at /root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:2962:29                                                                                                  
    at wrapper (/root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:273:20)                                                                                         
    at iteratorCallback (/root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:501:17)
    at /root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:329:20             
    at /root/cryptonote-nodejs-pool/node_modules/async/dist/async.js:2959:17                                                                                                  
    at /root/cryptonote-nodejs-pool/lib/blockUnlocker.js:104:6                                                                                                                
    at /root/cryptonote-nodejs-pool/lib/apiInterfaces.js:65:3                                                                                                                 
    at IncomingMessage.<anonymous> (/root/cryptonote-nodejs-pool/lib/apiInterfaces.js:41:5)
    at IncomingMessage.emit (events.js:412:35)                                        
    at endReadableNT (internal/streams/readable.js:1333:12)                                                                                                                 
    at processTicksAndRejections (internal/process/task_queues.js:82:21)
```
    
Changing the async version to `async@1.5.2` fixes this issues. It's either this solution or fix the code for `async@3.2.0` support.